### PR TITLE
Add support for authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,18 @@ and adjust the host name accordingly.
 Name               | Description
 -------------------|------------
 redis.addr         | Address of one or more redis nodes, comma separated, defaults to `localhost:6379`.
+redis.password     | Password to use when authenticating to Redis
 namespace          | Namespace for the metrics, defaults to `redis`.
 web.listen-address | Address to listen on for web interface and telemetry, defaults to `0.0.0.0:9121`.
 web.telemetry-path | Path under which to expose metrics, defaults to `metrics`.
 
+These settings take precedence over any configurations provided by [environment variables](#environment-variables).
+
+### Environment Variables
+
+Name               | Description
+-------------------|------------
+REDIS_PASSWORD     | Password to use when authenticating to Redis
 
 ### What's exported?
 

--- a/redis_exporter_test.go
+++ b/redis_exporter_test.go
@@ -71,7 +71,7 @@ func deleteKeysFromDB(t *testing.T, db string) error {
 
 func TestCountingKeys(t *testing.T) {
 
-	e := NewRedisExporter(addrs, "test")
+	e := NewRedisExporter(RedisHost{addrs: addrs}, "test")
 
 	scrapes := make(chan scrapeResult)
 	go e.scrape(scrapes)
@@ -118,7 +118,7 @@ func TestCountingKeys(t *testing.T) {
 
 func TestExporter(t *testing.T) {
 
-	e := NewRedisExporter(addrs, "test")
+	e := NewRedisExporter(RedisHost{addrs: addrs}, "test")
 
 	scrapes := make(chan scrapeResult)
 	go e.scrape(scrapes)


### PR DESCRIPTION
Adds the `redis.password` flag, which allows for authenticating connections to the Redis server or servers. To simplify the function signatures, a `RedisHost` structure was implemented to contain all information about the connection to Redis.

There weren't any test instructions, so I wasn't entirely sure how to proceed there, but I updated the portions of the test which used the `NewRedisExporter` to use the new `RedisHost` style. If you have any guidance on that I'll be happy to implement some tests for the authentication portions.