### PR TITLE
Support separate per-instance password when monitoring more than one Redis instance

### DIFF
--- a/exporter/redis.go
+++ b/exporter/redis.go
@@ -14,8 +14,8 @@ import (
 
 // RedisHost represents a set of Redis Hosts to health check.
 type RedisHost struct {
-	Addrs    []string
-	Password string
+	Addrs     []string
+	Passwords []string
 }
 
 // Exporter implementes the prometheus.Exporter interface, and exports Redis metrics.
@@ -237,15 +237,15 @@ func (e *Exporter) scrape(scrapes chan<- scrapeResult) {
 	e.totalScrapes.Inc()
 
 	errorCount := 0
-	for _, addr := range e.redis.Addrs {
+	for idx, addr := range e.redis.Addrs {
 		c, err := redis.Dial("tcp", addr)
 		if err != nil {
 			log.Printf("redis err: %s", err)
 			errorCount++
 			continue
 		}
-		if e.redis.Password != "" {
-			if _, err := c.Do("AUTH", e.redis.Password); err != nil {
+		if e.redis.Passwords[idx] != "" {
+			if _, err := c.Do("AUTH", e.redis.Passwords[idx]); err != nil {
 				log.Printf("redis err: %s", err)
 				errorCount++
 				continue

--- a/main.go
+++ b/main.go
@@ -13,9 +13,10 @@ import (
 )
 
 var (
-	redisAddr     = flag.String("redis.addr", "localhost:6379", "Address of one or more redis nodes, comma separated")
-	redisPassword = flag.String("redis.password", os.Getenv("REDIS_PASSWORD"), "Password one one or more redis nodes, comma separated")
+	redisAddr     = flag.String("redis.addr", "localhost:6379", "Address of one or more redis nodes, separated by separator")
+	redisPassword = flag.String("redis.password", os.Getenv("REDIS_PASSWORD"), "Password one one or more redis nodes, separated by separator")
 	namespace     = flag.String("namespace", "redis", "Namespace for metrics")
+	separator     = flag.String("separator", ",", "separator used to split redis.addr and redis.password into several elements.")
 	listenAddress = flag.String("web.listen-address", ":9121", "Address to listen on for web interface and telemetry.")
 	metricPath    = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
 	showVersion   = flag.Bool("version", false, "Show version information")
@@ -31,11 +32,11 @@ func main() {
 		return
 	}
 
-	addrs := strings.Split(*redisAddr, ",")
+	addrs := strings.Split(*redisAddr, *separator)
 	if len(addrs) == 0 || len(addrs[0]) == 0 {
 		log.Fatal("Invalid parameter --redis.addr")
 	}
-	passwords := strings.Split(*redisPassword, ",")
+	passwords := strings.Split(*redisPassword, *separator)
 	for len(passwords) < len(addrs) {
 		passwords = append(passwords, passwords[0])
 	}

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	redisAddr     = flag.String("redis.addr", "localhost:6379", "Address of one or more redis nodes, separated by separator")
-	redisPassword = flag.String("redis.password", os.Getenv("REDIS_PASSWORD"), "Password one one or more redis nodes, separated by separator")
+	redisPassword = flag.String("redis.password", os.Getenv("REDIS_PASSWORD"), "Password for one or more redis nodes, separated by separator")
 	namespace     = flag.String("namespace", "redis", "Namespace for metrics")
 	separator     = flag.String("separator", ",", "separator used to split redis.addr and redis.password into several elements.")
 	listenAddress = flag.String("web.listen-address", ":9121", "Address to listen on for web interface and telemetry.")


### PR DESCRIPTION
I have the use case where I have several Redis instances on one machine, each of them with separate passwords. The existing redis_exporter didn't support different passwords for different Redis instances yet, so I extended it by splitting up the redis.password flag just like redis.addr has been split up previously.