### PR TITLE
improve validation of -redis.addr

### DIFF
--- a/exporter/redis.go
+++ b/exporter/redis.go
@@ -116,7 +116,14 @@ func (e *Exporter) initGauges() {
 }
 
 // NewRedisExporter returns a new exporter of Redis metrics.
-func NewRedisExporter(redis RedisHost, namespace string) *Exporter {
+func NewRedisExporter(redis RedisHost, namespace string) (*Exporter, error) {
+	for _, addr := range redis.Addrs {
+		parts := strings.Split(addr, ":")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("Invalid parameter --redis.addr: %s", addr)
+		}
+	}
+
 	e := Exporter{
 		redis:     redis,
 		namespace: namespace,
@@ -139,7 +146,7 @@ func NewRedisExporter(redis RedisHost, namespace string) *Exporter {
 	}
 
 	e.initGauges()
-	return &e
+	return &e, nil
 }
 
 // Describe outputs Redis metric descriptions.

--- a/exporter/redis.go
+++ b/exporter/redis.go
@@ -203,9 +203,9 @@ func parseDBKeyspaceString(db string, stats string) (keysTotal float64, keysExpi
 		}
 		val, err = strconv.ParseFloat(split[1], 64)
 		if err != nil {
-                        log.Printf("couldn't parse %s, err: %s", split[1], err)
-                        return 0, fmt.Errorf("nope")
-                }
+			log.Printf("couldn't parse %s, err: %s", split[1], err)
+			return 0, fmt.Errorf("nope")
+		}
 		return
 	}
 

--- a/exporter/redis_test.go
+++ b/exporter/redis_test.go
@@ -99,7 +99,7 @@ func TestCountingKeys(t *testing.T) {
 	scrapes := make(chan scrapeResult)
 	go e.scrape(scrapes)
 
-	var keysTestDB float64 = 0
+	var keysTestDB float64
 	for s := range scrapes {
 		if s.Name == "db_keys_total" && s.DB == dbNumStrFull {
 			keysTestDB = s.Value

--- a/main.go
+++ b/main.go
@@ -33,15 +33,15 @@ func main() {
 	}
 
 	addrs := strings.Split(*redisAddr, *separator)
-	if len(addrs) == 0 || len(addrs[0]) == 0 {
-		log.Fatal("Invalid parameter --redis.addr")
-	}
 	passwords := strings.Split(*redisPassword, *separator)
 	for len(passwords) < len(addrs) {
 		passwords = append(passwords, passwords[0])
 	}
 
-	e := exporter.NewRedisExporter(exporter.RedisHost{addrs, passwords}, *namespace)
+	e, err := exporter.NewRedisExporter(exporter.RedisHost{Addrs: addrs, Passwords: passwords}, *namespace)
+	if err != nil {
+		log.Fatal(err)
+	}
 	prometheus.MustRegister(e)
 
 	http.Handle(*metricPath, prometheus.Handler())


### PR DESCRIPTION
Fixes #20 

- moved validation of `-redis.addr` into `NewRedisExporter()` so that it is easier to test
- added test cases

@oliver006 let me know what you think, happy to adapt to your feedback