### PR TITLE
Use `redis_up` for templating

### DIFF
--- a/grafana_prometheus_redis_dashboard.json
+++ b/grafana_prometheus_redis_dashboard.json
@@ -1052,7 +1052,7 @@
         "multi": false,
         "name": "addr",
         "options": [],
-        "query": "label_values(redis_connected_clients, addr)",
+        "query": "label_values(redis_up, addr)",
         "refresh": 1,
         "regex": "",
         "type": "query"


### PR DESCRIPTION
Believe it or not, I had a redis instance with no connected clients, so the templating failed.
`redis_up` is probably a more "robust" choice.