### PR TITLE
Really make builds static

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+export CGO_ENABLED=0
 
 echo "Building binaries"
 echo ""

--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,6 @@ machine:
     SRC_LOCATION:     "/home/ubuntu/.go_workspace/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
     COVERAGE_PROFILE: "/home/ubuntu/coverage.out"
     GO_LDFLAGS:       '-extldflags "-static" -X main.VERSION=$CIRCLE_TAG -X main.COMMIT_SHA1=$CIRCLE_SHA1 -X main.BUILD_DATE=$(date +%F-%T)'
-    CGO_ENABLED:      "0"
     MY_GO_VERSION:    "1.8"
 
 dependencies:

--- a/circle.yml
+++ b/circle.yml
@@ -9,6 +9,7 @@ machine:
     SRC_LOCATION:     "/home/ubuntu/.go_workspace/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
     COVERAGE_PROFILE: "/home/ubuntu/coverage.out"
     GO_LDFLAGS:       '-extldflags "-static" -X main.VERSION=$CIRCLE_TAG -X main.COMMIT_SHA1=$CIRCLE_SHA1 -X main.BUILD_DATE=$(date +%F-%T)'
+    CGO_ENABLED:      "0"
     MY_GO_VERSION:    "1.8"
 
 dependencies:


### PR DESCRIPTION
Sorry to bug you again @oliver006 - I downloaded your latest release v0.10.9 but it sadly still fails in my Docker container since the binary is still dynamically linked. I researched and experimented locally and found out that additionally the environment variable CGO_ENABLED=0 is needed. Running `file redis_exporter` should yield (note the **statically linked**):

```
redis_exporter: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, not stripped
```

I hope my provided patch for the circle.yml will let CircleCI build static binaries now.