### PR TITLE
[RDY] Support passing a file containing redis hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ check-keys         | Comma separated list of keys to export value and length/siz
 redis.addr         | Address of one or more redis nodes, comma separated, defaults to `redis://localhost:6379`.
 redis.password     | Password to use when authenticating to Redis
 redis.alias        | Alias for redis node addr, comma separated.
+redis.file         | Path to file containing one or more redis nodes, separated by newline. This option is mutually exclusive with redis.addr. Each line can optionally be comma-separated with the fields <addr>,<password>,<alias>.
 namespace          | Namespace for the metrics, defaults to `redis`.
 web.listen-address | Address to listen on for web interface and telemetry, defaults to `0.0.0.0:9121`.
 web.telemetry-path | Path under which to expose metrics, defaults to `metrics`.
@@ -64,6 +65,7 @@ Name               | Description
 REDIS_ADDR         | Address of Redis node(s)
 REDIS_PASSWORD     | Password to use when authenticating to Redis
 REDIS_ALIAS        | Alias name of Redis node(s)
+REDIS_FILE         | Path to file containing Redis node(s)
 
 ### What's exported?
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/csv"
 	"flag"
 	"net/http"
 	"os"
@@ -13,7 +14,8 @@ import (
 )
 
 var (
-	redisAddr     = flag.String("redis.addr", getEnv("REDIS_ADDR", "redis://localhost:6379"), "Address of one or more redis nodes, separated by separator")
+	redisAddr     = flag.String("redis.addr", getEnv("REDIS_ADDR", ""), "Address of one or more redis nodes, separated by separator")
+	redisFile     = flag.String("redis.file", getEnv("REDIS_FILE", ""), "Path to file containing one or more redis nodes, separated by newline. NOTE: mutually exclusive with redis.addr")
 	redisPassword = flag.String("redis.password", getEnv("REDIS_PASSWORD", ""), "Password for one or more redis nodes, separated by separator")
 	redisAlias    = flag.String("redis.alias", getEnv("REDIS_ALIAS", ""), "Redis instance alias for one or more redis nodes, separated by separator")
 	namespace     = flag.String("namespace", "redis", "Namespace for metrics")
@@ -24,6 +26,9 @@ var (
 	isDebug       = flag.Bool("debug", false, "Output verbose debug information")
 	logFormat     = flag.String("log-format", "txt", "Log format, valid options are txt and json")
 	showVersion   = flag.Bool("version", false, "Show version information and exit")
+	addrs         []string
+	passwords     []string
+	aliases       []string
 
 	// VERSION, BUILD_DATE, GIT_COMMIT are filled in by the build script
 	VERSION     = "<<< filled in by build >>>"
@@ -54,14 +59,18 @@ func main() {
 		return
 	}
 
-	addrs := strings.Split(*redisAddr, *separator)
-	passwords := strings.Split(*redisPassword, *separator)
-	for len(passwords) < len(addrs) {
-		passwords = append(passwords, passwords[0])
+	if *redisFile != "" && *redisAddr != "" {
+		log.Fatal("Cannot specify both redis.addr and redis.file")
 	}
-	aliases := strings.Split(*redisAlias, *separator)
-	for len(aliases) < len(addrs) {
-		aliases = append(aliases, aliases[0])
+
+	if *redisFile != "" {
+		var err error
+		addrs, passwords, aliases, err = loadRedisFile(*redisFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		addrs, passwords, aliases = loadRedisArgs(*redisAddr, *redisPassword, *redisAlias, *separator)
 	}
 
 	exp, err := exporter.NewRedisExporter(
@@ -97,6 +106,64 @@ func main() {
 	log.Printf("Connecting to redis hosts: %#v", addrs)
 	log.Printf("Using alias: %#v", aliases)
 	log.Fatal(http.ListenAndServe(*listenAddress, nil))
+}
+
+// loadRedisArgs loads the configuration for which redis hosts to monitor from either
+// the environment or as passed from program arguments. Returns the list of host addrs,
+// passwords, and their aliases.
+func loadRedisArgs(addr, password, alias, separator string) ([]string, []string, []string) {
+	if addr == "" {
+		addr = "redis://localhost:6379"
+	}
+	addrs = strings.Split(addr, separator)
+	passwords = strings.Split(password, separator)
+	for len(passwords) < len(addrs) {
+		passwords = append(passwords, passwords[0])
+	}
+	aliases = strings.Split(alias, separator)
+	for len(aliases) < len(addrs) {
+		aliases = append(aliases, aliases[0])
+	}
+	return addrs, passwords, aliases
+}
+
+// loadRedisFile opens the specified file and loads the configuration for which redis
+// hosts to monitor. Returns the list of hosts addrs, passwords, and their aliases.
+func loadRedisFile(fileName string) ([]string, []string, []string, error) {
+	var addrs []string
+	var passwords []string
+	var aliases []string
+	file, err := os.Open(fileName)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	r := csv.NewReader(file)
+	r.FieldsPerRecord = -1
+	records, err := r.ReadAll()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	file.Close()
+	// For each line, test if it contains an optional password and alias and provide them,
+	// else give them empty strings
+	for _, record := range records {
+		length := len(record)
+		switch length {
+		case 3:
+			addrs = append(addrs, record[0])
+			passwords = append(passwords, record[1])
+			aliases = append(aliases, record[2])
+		case 2:
+			addrs = append(addrs, record[0])
+			passwords = append(passwords, record[1])
+			aliases = append(aliases, "")
+		case 1:
+			addrs = append(addrs, record[0])
+			passwords = append(passwords, "")
+			aliases = append(aliases, "")
+		}
+	}
+	return addrs, passwords, aliases, nil
 }
 
 // getEnv gets an environment variable from a given key and if it doesn't exist,


### PR DESCRIPTION
This allows one to manage a file separately from the service definition
and simply restart the service once the configured file is updated.