### PR TITLE
[glide] Update sirupsen dependency to use new path to repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ redis_exporter
 coverage.out
 pkg/
 src/
+vendor/

--- a/exporter/redis.go
+++ b/exporter/redis.go
@@ -8,9 +8,9 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/garyburd/redigo/redis"
 	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
 )
 
 // RedisHost represents a set of Redis Hosts to health check.

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: f3c633e6d67c8abb2591436c5713662b6e90e48b2577ccfd9ed80338d9b11834
-updated: 2017-09-20T10:35:35.134287592+02:00
+hash: a7c02256b12a590f5b43639325817155ea183b8196727e182c51cdb8e06145ea
+updated: 2017-10-16T19:10:37.60453427-04:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -13,7 +13,7 @@ imports:
   - internal
   - redis
 - name: github.com/golang/protobuf
-  version: ae59567b9aab61b50b2590679a62c3c044030b61
+  version: 3852dcfda249c2097355a6aabb199a28d97b30df
   subpackages:
   - proto
 - name: github.com/matttproud/golang_protobuf_extensions
@@ -21,7 +21,7 @@ imports:
   subpackages:
   - pbutil
 - name: github.com/mitchellh/mapstructure
-  version: d0303fe809921458f417bcf828397a65db30a7e4
+  version: 53818660ed4955e899c0bcafa97299a388bd7c8e
 - name: github.com/prometheus/client_golang
   version: c5b7fccd204277076155f10851dad72b76a49317
   subpackages:
@@ -31,19 +31,17 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 2f17f4a9d485bf34b4bfaccc273805040e4f86c8
+  version: 9e0844febd9e2856f839c9cb974fbd676d1755a8
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2
-  subpackages:
-  - xfs
-- name: github.com/Sirupsen/logrus
+  version: 1878d9fbb537119d24b21ca07effd591627cd160
+- name: github.com/sirupsen/logrus
   version: d26492970760ca5d33129d2d799e34be5c4782eb
 - name: golang.org/x/sys
-  version: b6e1ae21643682ce023deb8d152024597b0e9bb4
+  version: d4feaf1a7e61e1d9e79e6c4e76c6349e9cab0a03
   subpackages:
   - unix
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,6 @@
 package: github.com/oliver006/redis_exporter
 import:
-- package: github.com/Sirupsen/logrus
+- package: github.com/sirupsen/logrus
   version: v0.11.0
 - package: github.com/garyburd/redigo
   version: v1.0.0

--- a/main.go
+++ b/main.go
@@ -8,10 +8,10 @@ import (
 	"runtime"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/cloudfoundry-community/go-cfenv"
 	"github.com/oliver006/redis_exporter/exporter"
 	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
 )
 
 var (


### PR DESCRIPTION
Hi! The `github.com/Sirupsen/logrus` repo recently moved to `github/sirupsen/logrus` so this PR updates `redis_exporter` to use the new path and updates glide as well. Without this change, glide is unable to install its dependencies correctly because it can't find the `logrus` package. Specifically, it reports:

```
[ERROR] Update failed for github.com/Sirupsen/logrus: The Remote does not match the VCS endpoint
[ERROR] Failed to install: The Remote does not match the VCS endpoint
```

I also took the liberty of adding the `vendor` directory to `.gitignore`. Happy to revert if you feel it should be left out though. Thanks!