### PR TITLE
support redis-sentinel with k8s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage.out
 pkg/
 src/
 vendor/
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9 as builder
+FROM golang:1.8.3 as builder
 
 ARG VERSION=0.0.1
 WORKDIR /go/src/github.com/oliver006/redis_exporter

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,20 @@
-FROM gliderlabs/alpine
+FROM golang:1.9 as builder
+
+ARG VERSION=0.0.1
+WORKDIR /go/src/github.com/oliver006/redis_exporter
+
+COPY . .
+
+RUN go get -d -v .
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo  -ldflags "-X main.VERSION=${VERSION} -X main.BUILD_DATE=$(date +%F-%T) -X main.COMMIT_SHA1=`git rev-parse HEAD`" -o redis_exporter .
+
+
+FROM bash:latest
 MAINTAINER Oliver <oliver@21zoo.com>
 
-COPY dist/redis_exporter /bin/redis_exporter
+COPY --from=builder /go/src/github.com/oliver006/redis_exporter/redis_exporter /bin/redis_exporter
+COPY entrypoint.sh /entrypoint.sh
 
-EXPOSE     9121
-ENTRYPOINT [ "/bin/redis_exporter" ]
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Locally build and run it:
     $ ./redis_exporter <flags>
 ```
 
+Locally build and run it via docker:
+```
+    $ docker build --build-arg VERSION=0.0.2 -t oliver006/redis_export .
+```
 You can also run it via docker:
 
 ```
@@ -42,6 +46,13 @@ To run on Cloud Foundry, use:
 cf push -f contrib/manifest.yml
 ```
 
+To run on Kubernetes
+```
+    $ kubectl create -f contrib/kube-redis-exporter-with-redis-sentinel.yaml
+    $ kubectl scale statefulset redis --replicas=3
+    $ kubectl get pod
+    $ kubectl logs  $(kubectl get pods --selector=name=redis-exporter -n default --output=jsonpath={.items..metadata.name})
+```
 
 ### Flags
 

--- a/build.sh
+++ b/build.sh
@@ -20,21 +20,16 @@ echo "Upload to Github"
 ghr -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME --replace $CIRCLE_TAG dist/
 
 
+echo "Build Docker images"
+
 docker version
 
-gox --osarch="linux/386"   -ldflags "$GO_LDFLAGS" -output "dist/redis_exporter"
-
-echo "Build Docker images"
-docker build --rm=false -t "21zoo/redis_exporter:$CIRCLE_TAG" .
-docker build --rm=false -t "21zoo/redis_exporter:latest" .
+docker build --rm=false --build-arg VERSION=$CIRCLE_TAG -t "21zoo/redis_exporter:$CIRCLE_TAG" .
+docker tag "21zoo/redis_exporter:$CIRCLE_TAG" "oliver006/redis_exporter:$CIRCLE_TAG"
 
 docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
-docker push "21zoo/redis_exporter:latest"
-docker push "21zoo/redis_exporter:$CIRCLE_TAG"
 
-docker build --rm=false -t "oliver006/redis_exporter:$CIRCLE_TAG" .
-docker build --rm=false -t "oliver006/redis_exporter:latest" .
-docker push "oliver006/redis_exporter:latest"
+docker push "21zoo/redis_exporter:$CIRCLE_TAG"
 docker push "oliver006/redis_exporter:$CIRCLE_TAG"
 
 echo "Done"

--- a/contrib/kube-redis-exporter-with-redis-sentinel.yaml
+++ b/contrib/kube-redis-exporter-with-redis-sentinel.yaml
@@ -1,0 +1,118 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: sentinel
+    role: service
+  name: redis-sentinel
+spec:
+  ports:
+    - port: 26379
+      targetPort: 26379
+  selector:
+    redis-sentinel: "true"
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: redis
+spec:
+  serviceName: redis-sentinel
+  replicas: 1
+  selector:
+    matchLabels:
+      name: sentinel
+  template:
+    metadata:
+      labels:
+        name: sentinel
+        redis-sentinel: "true"
+#      annotations:
+#        security.alpha.kubernetes.io/unsafe-sysctls: net.core.somaxconn=1024
+    spec:
+      containers:
+      - name: redis
+        image: cookingcodewithme/redis:latest
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 6379
+        resources:
+          limits:
+            cpu: "0.5"
+#        volumeMounts:
+#        - mountPath: /redis-master-data
+#          name: data
+      - name: sentinel
+        image: cookingcodewithme/redis:latest
+        imagePullPolicy: Always
+        env:
+          - name: SENTINEL
+            value: "true"
+        ports:
+          - containerPort: 26379
+#      volumes:
+#        - name: data
+#          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: default
+  name: redis-exporter
+  labels:
+    name: redis-exporter
+spec:
+  ports:
+  - name: redis-exporter
+    port: 9121
+  selector:
+    name: redis-exporter
+
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  namespace: default
+  name: redis-exporter
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: redis-exporter
+    spec:
+      containers:
+        - name: redis-exporter
+          image: cookingcodewithme/redis_export:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "0.1"
+          ports:
+            - name: redis-exporter
+              containerPort: 9121
+          env:
+            - name: REDIS_ADDR
+              value: "redis-sentinel.default.svc.cluster.local:26379"
+            - name: ARGS
+              value: "-use-redis-sentinel -debug"
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  namespace: monitoring
+  name: redis-exporter
+  labels:
+    team: frontend
+spec:
+  namespaceSelector:
+    matchNames:
+      - default
+  selector:
+    matchLabels:
+      name: redis-exporter
+  endpoints:
+  - port: redis-exporter
+    interval: 30s
+    path: /metrics

--- a/contrib/kube-redis-exporter.yaml
+++ b/contrib/kube-redis-exporter.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: default
+  name: redis-exporter
+  labels:
+    name: redis-exporter
+spec:
+  ports:
+  - name: redis-exporter
+    port: 9121
+  selector:
+    name: redis-exporter
+
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  namespace: default
+  name: redis-exporter
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: redis-exporter
+    spec:
+      containers:
+        - name: redis-exporter
+          image: cookingcodewithme/redis_export:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "0.1"
+          ports:
+            - name: redis-exporter
+              containerPort: 9121
+          env:
+            - name: REDIS_ADDR
+              value: "redis-sentinel.default.svc.cluster.local:26379"
+            - name: ARGS
+              value: "-use-redis-sentinel -debug"
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  namespace: monitoring
+  name: redis-exporter
+  labels:
+    team: frontend
+spec:
+  namespaceSelector:
+    matchNames:
+      - default
+  selector:
+    matchLabels:
+      name: redis-exporter
+  endpoints:
+  - port: redis-exporter
+    interval: 30s
+    path: /metrics

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+#set -o xtrace
+
+[[ ${ARGS:-} ]] || ARGS=""
+
+/bin/redis_exporter $ARGS

--- a/main.go
+++ b/main.go
@@ -12,7 +12,10 @@ import (
 	"github.com/oliver006/redis_exporter/exporter"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	sentinel "github.com/FZambia/go-sentinel"
+	"github.com/garyburd/redigo/redis"
 	log "github.com/sirupsen/logrus"
+	"time"
 )
 
 var (
@@ -20,6 +23,7 @@ var (
 	redisFile        = flag.String("redis.file", getEnv("REDIS_FILE", ""), "Path to file containing one or more redis nodes, separated by newline. NOTE: mutually exclusive with redis.addr")
 	redisPassword    = flag.String("redis.password", getEnv("REDIS_PASSWORD", ""), "Password for one or more redis nodes, separated by separator")
 	redisAlias       = flag.String("redis.alias", getEnv("REDIS_ALIAS", ""), "Redis instance alias for one or more redis nodes, separated by separator")
+	masterName  	 = flag.String("redis.sentinel.master", getEnv("REDIS_SENTINEL_MASTER", "mymaster"), "name of the master node.")
 	namespace        = flag.String("namespace", "redis", "Namespace for metrics")
 	checkKeys        = flag.String("check-keys", "", "Comma separated list of keys to export value and length/size")
 	separator        = flag.String("separator", ",", "separator used to split redis.addr, redis.password and redis.alias into several elements.")
@@ -29,6 +33,7 @@ var (
 	logFormat        = flag.String("log-format", "txt", "Log format, valid options are txt and json")
 	showVersion      = flag.Bool("version", false, "Show version information and exit")
 	useCfBindings    = flag.Bool("use-cf-bindings", false, "Use Cloud Foundry service bindings")
+	useRedisSentinel = flag.Bool("use-redis-sentinel", false, "Use Redis Sentinel service")
 	redisMetricsOnly = flag.Bool("redis-only-metrics", false, "Whether to export go runtime metrics also")
 	addrs            []string
 	passwords        []string
@@ -77,6 +82,12 @@ func main() {
 		}
 	case *useCfBindings:
 		addrs, passwords, aliases = getCloudFoundryRedisBindings()
+	case *useRedisSentinel:
+		var err error
+		addrs, passwords, aliases, err = loadRedisSentinel(*redisAddr, *redisPassword, *redisAlias,*separator)
+		if err != nil {
+			log.Fatal(err)
+		}
 	default:
 		addrs, passwords, aliases = loadRedisArgs(*redisAddr, *redisPassword, *redisAlias, *separator)
 	}
@@ -221,4 +232,55 @@ func getCloudFoundryRedisBindings() (addrs, passwords, aliases []string) {
 	}
 
 	return
+}
+
+// loadRedisSentinel gets Redis IP addresses and Ports and return proper information.
+func loadRedisSentinel(addr, password, alias, separator string) ([]string, []string, []string, error) {
+	passwords = strings.Split(password, separator)
+	aliases = strings.Split(alias, separator)
+
+	options := []redis.DialOption{
+		redis.DialConnectTimeout(5 * time.Second),
+		redis.DialReadTimeout(5 * time.Second),
+		redis.DialWriteTimeout(5 * time.Second),
+	}
+
+	sentinel_addrs := strings.Split(addr, separator)
+	sntnl := &sentinel.Sentinel{Addrs: sentinel_addrs, MasterName: *masterName,
+		Dial: func(addr string) (redis.Conn, error) {
+			c, err := redis.Dial("tcp", addr, options...)
+			if err != nil {
+				return nil, err
+			}
+			return c, nil
+		},
+	}
+
+	var addrs []string
+	master, err := sntnl.MasterAddr()
+	if err != nil {
+		log.Warnln("Error while getting address of redis master", err)
+		return nil, nil, nil, err
+	} else {
+		addrs=append(addrs, master)
+
+		slaves, err := sntnl.Slaves()
+		if err != nil {
+			log.Warnln("Error while getting addresses of redis slaves", err)
+			return nil, nil, nil, err
+		} else {
+			for _, slave := range slaves {
+				if (true == slave.Available()) {
+					addrs=append(addrs,slave.Addr())
+					for len(passwords) < len(addrs) {
+						passwords = append(passwords, passwords[0])
+					}
+					for len(aliases) < len(addrs) {
+						aliases = append(aliases, aliases[0])
+					}
+				}
+			}
+			return addrs, passwords, aliases, nil
+		}
+	}
 }


### PR DESCRIPTION
Hello @oliver006,

I have updated redis_exporter for monitoring redis-sentinel on Kubernetes.

You can find changes below.
- add a new parameter as "-use-redis-sentinel" for retrieving redis master and slaves.
- add 2 kube-redis-exporter.yaml and  kube-redis-exporter-with-redis-sentinel.yaml 
- update the Dockerfile to use multi stage build.
- update README.md
- update build.sh to use docker tag instead of build image.

I haven't tested build process. But, I don't have any problems to use new Dockerfile and updated redis_exporter with K8S, Prometheus and Grafana.

Please feel free to review and let me know if you have any questions.
