### PR TITLE
Get metric for empty value of redis keySize

### DIFF
--- a/exporter/redis.go
+++ b/exporter/redis.go
@@ -595,9 +595,13 @@ func (e *Exporter) scrapeRedisHost(scrapes chan<- scrapeResult, addr string, idx
 
 		obtainedKeys := []string{}
 		if tempVal, err := redis.Strings(c.Do("KEYS", k.key)); err == nil && tempVal != nil {
-			for _, tempKey := range tempVal {
-				log.Debugf("Append result: %s", tempKey)
-				obtainedKeys = append(obtainedKeys, tempKey)
+			if len(tempVal) > 0 {
+				for _, tempKey := range tempVal {
+					log.Debugf("Append result: %s", tempKey)
+					obtainedKeys = append(obtainedKeys, tempKey)
+				}
+			} else {
+				obtainedKeys = append(obtainedKeys, k.key)
 			}
 		}
 

--- a/exporter/redis_test.go
+++ b/exporter/redis_test.go
@@ -769,14 +769,6 @@ func TestKeysReset(t *testing.T) {
 	if !bytes.Contains(body, []byte(keys[0])) {
 		t.Errorf("Did not found key %q\n%s", keys[0], body)
 	}
-
-	deleteKeysFromDB(t, defaultRedisHost.Addrs[0])
-
-	body = getMetrics(t)
-
-	if bytes.Contains(body, []byte(keys[0])) {
-		t.Errorf("Metric is present in metrics list %q\n%s", keys[0], body)
-	}
 }
 
 func init() {


### PR DESCRIPTION
current exporter do not gather metric from redis for empty key(s)
I want to monitor the size of some specific keys, even if the size is 0 such as empty list.

I'm not sure this changes are right way to go on, but please let me know if there is better way to solve my problem properly.