### PR TITLE
Add `maxclients` to config metrics

### DIFF
--- a/exporter/redis.go
+++ b/exporter/redis.go
@@ -387,7 +387,8 @@ func extractConfigMetrics(config []string, addr string, alias string, scrapes ch
 
 		// todo: we can add more configs to this map if there's interest
 		if !map[string]bool{
-			"maxmemory": true,
+			"maxmemory":  true,
+			"maxclients": true,
 		}[strKey] {
 			continue
 		}

--- a/exporter/redis_test.go
+++ b/exporter/redis_test.go
@@ -325,6 +325,7 @@ func TestExporterMetrics(t *testing.T) {
 		"used_cpu_sys",
 		"loading_dump_file", // testing renames
 		"config_maxmemory",  // testing config extraction
+		"config_maxclients", // testing config extraction
 	}
 
 	for _, k := range wantKeys {


### PR DESCRIPTION
I would like to be able to monitor connected clients vs. the configured `maxclients` setting.