### PR TITLE
Optional Redis Lua script for metric collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Name               | Description
 debug              | Verbose debug output
 log-format         | Log format, valid options are `txt` (default) and `json`.
 check-keys         | Comma separated list of keys to export value and length/size, eg: `db3=user_count` will export key `user_count` from db `3`. db defaults to `0` if omitted.
+script             | Path to Redis Lua script for gathering extra metrics.
 redis.addr         | Address of one or more redis nodes, comma separated, defaults to `redis://localhost:6379`.
 redis.password     | Password to use when authenticating to Redis
 redis.alias        | Alias for redis node addr, comma separated.
@@ -121,6 +122,7 @@ see http://redis.io/commands/info for details.<br>
 In addition, for every database there are metrics for total keys, expiring keys and the average TTL for keys in the database.<br>
 You can also export values of keys if they're in numeric format by using the `-check-keys` flag. The exporter will also export the size (or, depending on the data type, the length) of the key. This can be used to export the number of elements in (sorted) sets, hashes, lists, etc. <br>
 
+If you require custom metric collection, you can provide a [Redis Lua script](https://redis.io/commands/eval) using the `-script` flag. An example can be found [in the contrib folder](./contrib/sample_collect_script.lua).
 
 ### What does it look like?
 Example [Grafana](http://grafana.org/) screenshots:<br>

--- a/contrib/sample_collect_script.lua
+++ b/contrib/sample_collect_script.lua
@@ -1,0 +1,21 @@
+-- Example collect script for -script option
+-- This returns a Lua table with alternating keys and values.
+-- Both keys and values must be strings, similar to a HGETALL result.
+-- More info about Redis Lua scripting: https://redis.io/commands/eval
+
+local result = {}
+
+-- Add all keys and values from some hash in db 5
+redis.call("SELECT", 5)
+local r = redis.call("HGETALL", "some-hash-with-stats")
+if r ~= nil then
+    for _,v in ipairs(r) do
+        table.insert(result, v) -- alternating keys and values
+    end
+end
+
+-- Set foo to 42
+table.insert(result, "foo")
+table.insert(result, "42") -- note the string, use tostring() if needed
+
+return result

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"runtime"
@@ -19,6 +20,7 @@ var (
 	redisAlias       = flag.String("redis.alias", getEnv("REDIS_ALIAS", ""), "Redis instance alias for one or more redis nodes, separated by separator")
 	namespace        = flag.String("namespace", "redis", "Namespace for metrics")
 	checkKeys        = flag.String("check-keys", "", "Comma separated list of keys to export value and length/size")
+	scriptPath       = flag.String("script", "", "Path to Lua Redis script for collecting extra metrics")
 	separator        = flag.String("separator", ",", "separator used to split redis.addr, redis.password and redis.alias into several elements.")
 	listenAddress    = flag.String("web.listen-address", ":9121", "Address to listen on for web interface and telemetry.")
 	metricPath       = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
@@ -90,6 +92,14 @@ func main() {
 		*checkKeys)
 	if err != nil {
 		log.Fatal(err)
+	}
+
+	if *scriptPath != "" {
+		script, err := ioutil.ReadFile(*scriptPath)
+		if err != nil {
+			log.Fatalf("Error loading script file: %v", err)
+		}
+		exp.SetScript(script)
 	}
 
 	buildInfo := prometheus.NewGaugeVec(prometheus.GaugeOpts{


### PR DESCRIPTION
Allow an optional Redis Lua script to collect extra metrics.

This can be enabled with a new `-script` flag. An example script is provided in contrib.

I needed a way to export metrics that are collected within a Redis hash and `-check-keys` does not support this. Adding support for [Redis Lua scripts](https://redis.io/commands/eval) allows a user to collect whatever metrics they want from Redis without writing a custom exporter.

The script metrics end up in a new `redis_script_value` vector.