### PR TITLE
Pull request for issue "All configs with env variables"

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"runtime"
+        "strconv"
 
 	"github.com/oliver006/redis_exporter/exporter"
 	"github.com/prometheus/client_golang/prometheus"
@@ -18,18 +19,18 @@ var (
 	redisFile        = flag.String("redis.file", getEnv("REDIS_FILE", ""), "Path to file containing one or more redis nodes, separated by newline. NOTE: mutually exclusive with redis.addr")
 	redisPassword    = flag.String("redis.password", getEnv("REDIS_PASSWORD", ""), "Password for one or more redis nodes, separated by separator")
 	redisAlias       = flag.String("redis.alias", getEnv("REDIS_ALIAS", ""), "Redis instance alias for one or more redis nodes, separated by separator")
-	namespace        = flag.String("namespace", "redis", "Namespace for metrics")
-	checkKeys        = flag.String("check-keys", "", "Comma separated list of key-patterns to export value and length/size, searched for with SCAN")
-	checkSingleKeys  = flag.String("check-single-keys", "", "Comma separated list of single keys to export value and length/size")
-	scriptPath       = flag.String("script", "", "Path to Lua Redis script for collecting extra metrics")
-	separator        = flag.String("separator", ",", "separator used to split redis.addr, redis.password and redis.alias into several elements.")
-	listenAddress    = flag.String("web.listen-address", ":9121", "Address to listen on for web interface and telemetry.")
-	metricPath       = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
-	isDebug          = flag.Bool("debug", false, "Output verbose debug information")
-	logFormat        = flag.String("log-format", "txt", "Log format, valid options are txt and json")
-	showVersion      = flag.Bool("version", false, "Show version information and exit")
-	useCfBindings    = flag.Bool("use-cf-bindings", false, "Use Cloud Foundry service bindings")
-	redisMetricsOnly = flag.Bool("redis-only-metrics", false, "Whether to export go runtime metrics also")
+	namespace        = flag.String("namespace", getEnv("NAMESPACE", "redis"), "Namespace for metrics")
+	checkKeys        = flag.String("check-keys", getEnv("CHECK_KEYS", ""), "Comma separated list of key-patterns to export value and length/size, searched for with SCAN")
+	checkSingleKeys  = flag.String("check-single-keys", getEnv("CHECK_SINGLE_KEYS", ""), "Comma separated list of single keys to export value and length/size")
+	scriptPath       = flag.String("script", getEnv("SCRIPT", ""), "Path to Lua Redis script for collecting extra metrics")
+	separator        = flag.String("separator", getEnv("SEPARATOR", ","), "separator used to split redis.addr, redis.password and redis.alias into several elements.")
+	listenAddress    = flag.String("web.listen-address", getEnv("WEB_LISTEN_ADDRESS", ":9121"), "Address to listen on for web interface and telemetry.")
+	metricPath       = flag.String("web.telemetry-path", getEnv("WEB_TELEMETRY_PATH", "/metrics"), "Path under which to expose metrics.")
+	isDebug          = flag.Bool("debug", getEnvBool("DEBUG"), "Output verbose debug information")
+	logFormat        = flag.String("log-format", getEnv("LOG_FORMAT", "txt"), "Log format, valid options are txt and json")
+	showVersion      = flag.Bool("version", getEnvBool("VERSION"), "Show version information and exit")
+	useCfBindings    = flag.Bool("use-cf-bindings", getEnvBool("USE-CF-BINDINGS"), "Use Cloud Foundry service bindings")
+	redisMetricsOnly = flag.Bool("redis-only-metrics", getEnvBool("REDIS_ONLY_METRICS"), "Whether to export go runtime metrics also")
 
 	// VERSION, BUILD_DATE, GIT_COMMIT are filled in by the build script
 	VERSION     = "<<< filled in by build >>>"
@@ -42,6 +43,16 @@ func getEnv(key string, defaultVal string) string {
 		return envVal
 	}
 	return defaultVal
+}
+
+func getEnvBool(key string) bool {
+	if envVal, ok := os.LookupEnv(key); ok {
+		if envValBool, err := strconv.ParseBool(envVal); err ==nil {
+			return envValBool
+			}
+		return false
+	}
+	return false
 }
 
 func main() {


### PR DESCRIPTION
Added getEnvBool helper function to parse env variables of type boolean. Now all config parameters can be set as env variables. Things to consider:

1. The new helper function uses strconv because strings are converted to boolean via ParseBool. This accepts variations of true and false as well as 0 and 1. If there is a better way to achieve this I am all ears :)

2. Some of the names of env variables are too generic in my opinion and could cause issues on systems where other programs have set env variables with the same names. For example "DEBUG" and "VERSION" are two such env variables. Still, I decided to keep the format which has already been used and just capitalized the names the same way REDIS_FILE and REDIS_PASSWORD have been changed. We might want to change those env variable names.