### PR TITLE
Grafana Dashboards: Fix "Multiple Series Error" with Redis uptime Singlestat panels

### DIFF
--- a/contrib/grafana_prometheus_redis_dashboard.json
+++ b/contrib/grafana_prometheus_redis_dashboard.json
@@ -108,7 +108,7 @@
             "fillColor": "rgba(31, 118, 189, 0.18)",
             "full": false,
             "lineColor": "rgb(31, 120, 193)",
-            "show": false
+            "show": true
           },
           "targets": [
             {

--- a/contrib/grafana_prometheus_redis_dashboard.json
+++ b/contrib/grafana_prometheus_redis_dashboard.json
@@ -112,7 +112,7 @@
           },
           "targets": [
             {
-              "expr": "redis_uptime_in_seconds{addr=\"$addr\"}",
+              "expr": "max(max_over_time(redis_uptime_in_seconds{addr=\"$addr\"}[$__interval]))",
               "intervalFactor": 2,
               "legendFormat": "",
               "metric": "",
@@ -131,7 +131,7 @@
               "value": "null"
             }
           ],
-          "valueName": "avg"
+          "valueName": "current"
         },
         {
           "cacheTimeout": null,

--- a/contrib/grafana_prometheus_redis_dashboard_alias.json
+++ b/contrib/grafana_prometheus_redis_dashboard_alias.json
@@ -104,7 +104,7 @@
             "fillColor": "rgba(31, 118, 189, 0.18)",
             "full": false,
             "lineColor": "rgb(31, 120, 193)",
-            "show": false
+            "show": true
           },
           "targets": [
             {

--- a/contrib/grafana_prometheus_redis_dashboard_alias.json
+++ b/contrib/grafana_prometheus_redis_dashboard_alias.json
@@ -108,7 +108,7 @@
           },
           "targets": [
             {
-              "expr": "redis_uptime_in_seconds{instance=\"$host\",alias=\"$alias\"}",
+              "expr": "max(max_over_time(redis_uptime_in_seconds{instance=\"$host\",alias=\"$alias\"}[$__interval]))",
               "intervalFactor": 2,
               "legendFormat": "",
               "metric": "",
@@ -127,7 +127,7 @@
               "value": "null"
             }
           ],
-          "valueName": "avg"
+          "valueName": "current"
         },
         {
           "cacheTimeout": null,


### PR DESCRIPTION
## Problem:

When viewing Grafana dashboards with large enough time ranges to include periods when Grafana `Pod`s have been restarted or deleted & re-created, Prometheus queries return multiple series (See screenshot)

![Prometheus Multiple Series - screenshot 2018-08-24 16 02 33](https://user-images.githubusercontent.com/122524/44610157-3af8b900-a7b8-11e8-881b-365d6677811a.png)


The Grafana (>= 2.5) ["Singlestat" panel is designed only to handle single series](http://docs.grafana.org/features/panels/singlestat/#singlestat-panel), so returns a ["Multiple Series Error"](http://docs.grafana.org/features/panels/singlestat/#multiple-series-error) (see "before" Screenshot below) when viewed over time ranges where multiple Redis `Pod`s exist (`redis_exporter` metrics are tagged with multiple `instance=` names).

![Grafana Multiple Series Error - "before" screenshot 2018-08-24 15 53 26](https://user-images.githubusercontent.com/122524/44610183-5e236880-a7b8-11e8-92f2-c977611c6ce7.png)


## Solution:

Due to the data types Prometheus returns for these queries, we can use a couple tricks to solve the problem (See "after" screenshot below).

![Grafana Solved Multiple Series Error Problem - "after" screenshot 2018-08-24 15 52 58](https://user-images.githubusercontent.com/122524/44610672-6da3b100-a7ba-11e8-987f-5b5a95f72531.png)


Modifying the queries for `redis_uptime_in_seconds` to use the [Range Vector Selector](https://prometheus.io/docs/prometheus/latest/querying/basics/#range-vector-selectors) with Grafana [`[$__interval]` variable](http://docs.grafana.org/reference/templating/#interval-variables) allows for a more optimized and useful measurement of Uptime over custom ranges in Grafana.  Wrapping the queries in function calls to [`max_over_time`](https://prometheus.io/docs/prometheus/latest/querying/functions/#aggregation-_over_time) and [`max`](https://prometheus.io/docs/prometheus/latest/querying/operators/#aggregation-operators) allows for avoiding the "Multiple Series Error" problem with time periods returning multiple series by aggregating them to a single value compatible with the "Singlestat" panel. Given that `redis_exporter` `Pod` in the [official `redis` Helm chart](https://github.com/helm/charts/blob/master/stable/redis/README.md#metrics) should be running one-per Redis "release", it makes sense to use different release names and/or use the "`alias`" variant of this dashboard in that case.  Regardless, these aggregation functions should allow for "Uptime" in both dashboards to function properly and return single series values for the queries over whatever time ranges are selected.

#### Dashboard fixes:

- Fix "Multiple Series Error" for Uptime panels
- Use max current value over time interval (makes more sense for Uptime)
- Show sparklines for "Uptime" panel to indicate when pods were restarted in a time period