### PR TITLE
feat: add aof metrics

### DIFF
--- a/exporter/redis.go
+++ b/exporter/redis.go
@@ -88,6 +88,14 @@ var (
 		"aof_rewrite_scheduled":        "aof_rewrite_scheduled",
 		"aof_last_rewrite_time_sec":    "aof_last_rewrite_duration_sec",
 		"aof_current_rewrite_time_sec": "aof_current_rewrite_duration_sec",
+		"aof_last_cow_size":            "aof_last_cow_size",
+		"aof_current_size":             "aof_current_size",
+		"aof_base_size":                "aof_base_size",
+		"aof_pending_rewrite":          "aof_pending_rewrite",
+		"aof_buffer_length":            "aof_buffer_length",
+		"aof_rewrite_buffer_length":    "aof_rewrite_buffer_length",
+		"aof_pending_bio_fsync":        "aof_pending_bio_fsync",
+		"aof_delayed_fsync":            "aof_delayed_fsync",
 
 		// # Stats
 		"total_connections_received": "connections_received_total",


### PR DESCRIPTION
I'd like to extend list of AOF releated metrics. A server return few metrics if aof is disabled:

```
aof_enabled:0
aof_rewrite_in_progress:0
aof_rewrite_scheduled:0
aof_last_rewrite_time_sec:-1
aof_current_rewrite_time_sec:-1
aof_last_bgrewrite_status:ok
aof_last_write_status:ok
aof_last_cow_size:0
```
but if AOF is enabled we get additional interesting metrics:

```
127.0.0.1:6379> CONFIG set appendonly yes
OK

--
aof_enabled:1
aof_rewrite_in_progress:0
aof_rewrite_scheduled:0
aof_last_rewrite_time_sec:0
aof_current_rewrite_time_sec:-1
aof_last_bgrewrite_status:ok
aof_last_write_status:ok
aof_last_cow_size:200704
aof_current_size:92
aof_base_size:92
aof_pending_rewrite:0
aof_buffer_length:0
aof_rewrite_buffer_length:0
aof_pending_bio_fsync:0
aof_delayed_fsync:0
```

In this PR I added the metrics from the list above.

Thanks.
