### PR TITLE
Cleanup some metrics

### DIFF
--- a/exporter/redis.go
+++ b/exporter/redis.go
@@ -46,7 +46,8 @@ type Exporter struct {
 	scrapeErrors prometheus.Gauge
 	totalScrapes prometheus.Counter
 	metrics      map[string]*prometheus.GaugeVec
-	metricsMtx   sync.RWMutex
+
+	metricsMtx sync.RWMutex
 	sync.RWMutex
 }
 
@@ -71,13 +72,14 @@ var (
 		"blocked_clients":            "blocked_clients",
 
 		// # Memory
-		"used_memory":             "memory_used_bytes",
-		"used_memory_rss":         "memory_used_rss_bytes",
-		"used_memory_peak":        "memory_used_peak_bytes",
-		"used_memory_lua":         "memory_used_lua_bytes",
-		"total_system_memory":     "total_system_memory_bytes",
-		"maxmemory":               "memory_max_bytes",
-		"mem_fragmentation_ratio": "memory_fragmentation_ratio",
+		"allocator_active":    "allocator_active_bytes",
+		"allocator_allocated": "allocator_allocated_bytes",
+		"allocator_resident":  "allocator_resident_bytes",
+		"used_memory":         "memory_used_bytes",
+		"used_memory_rss":     "memory_used_rss_bytes",
+		"used_memory_peak":    "memory_used_peak_bytes",
+		"used_memory_lua":     "memory_used_lua_bytes",
+		"maxmemory":           "memory_max_bytes",
 
 		// # Persistence
 		"rdb_changes_since_last_save":  "rdb_changes_since_last_save",
@@ -192,15 +194,14 @@ func (e *Exporter) initGauges() {
 		Help:      "Length of the last latency spike in milliseconds",
 	}, []string{"addr", "alias", "event_name"})
 
-	// Emulate a Summary.
-	e.metrics["command_call_duration_seconds_count"] = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	e.metrics["commands_total"] = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: e.namespace,
-		Name:      "command_call_duration_seconds_count",
+		Name:      "commands_total",
 		Help:      "Total number of calls per command",
 	}, []string{"addr", "alias", "cmd"})
-	e.metrics["command_call_duration_seconds_sum"] = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	e.metrics["commands_duration_seconds_total"] = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: e.namespace,
-		Name:      "command_call_duration_seconds_sum",
+		Name:      "commands_duration_seconds_total",
 		Help:      "Total amount of time in seconds spent per command",
 	}, []string{"addr", "alias", "cmd"})
 	e.metrics["slowlog_length"] = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -566,8 +567,8 @@ func (e *Exporter) extractInfoMetrics(info, addr string, alias string, scrapes c
 			}
 
 			e.metricsMtx.RLock()
-			e.metrics["command_call_duration_seconds_count"].WithLabelValues(addr, alias, cmd).Set(calls)
-			e.metrics["command_call_duration_seconds_sum"].WithLabelValues(addr, alias, cmd).Set(usecTotal / 1e6)
+			e.metrics["commands_total"].WithLabelValues(addr, alias, cmd).Set(calls)
+			e.metrics["commands_duration_seconds_total"].WithLabelValues(addr, alias, cmd).Set(usecTotal / 1e6)
 			e.metricsMtx.RUnlock()
 			continue
 		}

--- a/exporter/redis_test.go
+++ b/exporter/redis_test.go
@@ -958,7 +958,7 @@ func TestCommandStats(t *testing.T) {
 		close(chM)
 	}()
 
-	want := map[string]bool{"test_command_call_duration_seconds_count": false, "test_command_call_duration_seconds_sum": false}
+	want := map[string]bool{"test_commands_duration_seconds_total": false, "test_commands_total": false}
 
 	for m := range chM {
 		switch m.(type) {


### PR DESCRIPTION
Remove `mem_fragmentation_ratio`:
* Comes from `redis_memory_used_rss_bytes / redis_memory_used_bytes`.
* Metric only provides 2 digits of accuracy compared to calculation.

Add allocator metrics.

Cleanup Prometheus naming of commands metrics names to avoid confusing
references to being a "Summary" metric, it's not.

Remove `total_system_memory`, this duplicates node_exporter metrics.

Signed-off-by: Ben Kochie <superq@gmail.com>