### PR TITLE
Bring back total_system_memory_bytes metric.

### DIFF
--- a/exporter/redis.go
+++ b/exporter/redis.go
@@ -79,6 +79,7 @@ var (
 		"used_memory_rss":     "memory_used_rss_bytes",
 		"used_memory_peak":    "memory_used_peak_bytes",
 		"used_memory_lua":     "memory_used_lua_bytes",
+		"total_system_memory": "total_system_memory_bytes",
 		"maxmemory":           "memory_max_bytes",
 
 		// # Persistence


### PR DESCRIPTION
As discussed in #228, added `total_system_memory_bytes` metric back.