### PR TITLE
Enable support for having the redis password in a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,22 +112,23 @@ cf push -f contrib/manifest.yml
 
 ### Flags
 
-Name               | Description
--------------------|------------
-debug              | Verbose debug output
-log-format         | Log format, valid options are `txt` (default) and `json`.
-check-keys         | Comma separated list of key patterns to export value and length/size, eg: `db3=user_count` will export key `user_count` from db `3`. db defaults to `0` if omitted. The key patterns specified with this flag will be found using [SCAN](https://redis.io/commands/scan).  Use this option if you need glob pattern matching; `check-single-keys` is faster for non-pattern keys.
-check-single-keys  | Comma separated list of keys to export value and length/size, eg: `db3=user_count` will export key `user_count` from db `3`. db defaults to `0` if omitted.  The keys specified with this flag will be looked up directly without any glob pattern matching.  Use this option if you don't need glob pattern matching;  it is faster than `check-keys`.
-script             | Path to Redis Lua script for gathering extra metrics.
-redis.addr         | Address of one or more redis nodes, comma separated, defaults to `redis://localhost:6379`.
-redis.password     | Password to use when authenticating to Redis
-redis.alias        | Alias for redis node addr, comma separated.
-redis.file         | Path to file containing one or more redis nodes, separated by newline. This option is mutually exclusive with redis.addr. Each line can optionally be comma-separated with the fields `<addr>,<password>,<alias>`. See [here](./contrib/sample_redis_hosts_file.txt) for an example file.
-namespace          | Namespace for the metrics, defaults to `redis`.
-web.listen-address | Address to listen on for web interface and telemetry, defaults to `0.0.0.0:9121`.
-web.telemetry-path | Path under which to expose metrics, defaults to `metrics`.
-use-cf-bindings    | Enable usage of Cloud Foundry service bindings. Defaults to `false`
-separator          | Separator used to split redis.addr, redis.password and redis.alias into several elements. Defaults to `,`
+Name                | Description
+--------------------|------------
+debug               | Verbose debug output
+log-format          | Log format, valid options are `txt` (default) and `json`.
+check-keys          | Comma separated list of key patterns to export value and length/size, eg: `db3=user_count` will export key `user_count` from db `3`. db defaults to `0` if omitted. The key patterns specified with this flag will be found using [SCAN](https://redis.io/commands/scan).  Use this option if you need glob pattern matching; `check-single-keys` is faster for non-pattern keys.
+check-single-keys   | Comma separated list of keys to export value and length/size, eg: `db3=user_count` will export key `user_count` from db `3`. db defaults to `0` if omitted.  The keys specified with this flag will be looked up directly without any glob pattern matching.  Use this option if you don't need glob pattern matching;  it is faster than `check-keys`.
+script              | Path to Redis Lua script for gathering extra metrics.
+redis.addr          | Address of one or more redis nodes, comma separated, defaults to `redis://localhost:6379`.
+redis.password      | Password to use when authenticating to Redis
+redis.password-file | Path to a file containing the password to use when authenticating to Redis (note: this is mutually exclusive with `redis.password`)
+redis.alias         | Alias for redis node addr, comma separated.
+redis.file          | Path to file containing one or more redis nodes, separated by newline. This option is mutually exclusive with redis.addr. Each line can optionally be comma-separated with the fields `<addr>,<password>,<alias>`. See [here](./contrib/sample_redis_hosts_file.txt) for an example file.
+namespace           | Namespace for the metrics, defaults to `redis`.
+web.listen-address  | Address to listen on for web interface and telemetry, defaults to `0.0.0.0:9121`.
+web.telemetry-path  | Path under which to expose metrics, defaults to `metrics`.
+use-cf-bindings     | Enable usage of Cloud Foundry service bindings. Defaults to `false`
+separator           | Separator used to split redis.addr, redis.password and redis.alias into several elements. Defaults to `,`
 
 Redis node addresses can be tcp addresses like `redis://localhost:6379`, `redis.example.com:6379` or unix socket addresses like `unix:///tmp/redis.sock`.\
 SSL is supported by using the `rediss://` schema, for example: `rediss://azure-ssl-enabled-host.redis.cache.windows.net:6380` (note that the port is required when connecting to a non-standard 6379 port, e.g. with Azure Redis instances).

--- a/main.go
+++ b/main.go
@@ -15,22 +15,23 @@ import (
 )
 
 var (
-	redisAddr        = flag.String("redis.addr", getEnv("REDIS_ADDR", ""), "Address of one or more redis nodes, separated by separator")
-	redisFile        = flag.String("redis.file", getEnv("REDIS_FILE", ""), "Path to file containing one or more redis nodes, separated by newline. NOTE: mutually exclusive with redis.addr")
-	redisPassword    = flag.String("redis.password", getEnv("REDIS_PASSWORD", ""), "Password for one or more redis nodes, separated by separator")
-	redisAlias       = flag.String("redis.alias", getEnv("REDIS_ALIAS", ""), "Redis instance alias for one or more redis nodes, separated by separator")
-	namespace        = flag.String("namespace", getEnv("REDIS_EXPORTER_NAMESPACE", "redis"), "Namespace for metrics")
-	checkKeys        = flag.String("check-keys", getEnv("REDIS_EXPORTER_CHECK_KEYS", ""), "Comma separated list of key-patterns to export value and length/size, searched for with SCAN")
-	checkSingleKeys  = flag.String("check-single-keys", getEnv("REDIS_EXPORTER_CHECK_SINGLE_KEYS", ""), "Comma separated list of single keys to export value and length/size")
-	scriptPath       = flag.String("script", getEnv("REDIS_EXPORTER_SCRIPT", ""), "Path to Lua Redis script for collecting extra metrics")
-	separator        = flag.String("separator", getEnv("REDIS_EXPORTER_SEPARATOR", ","), "separator used to split redis.addr, redis.password and redis.alias into several elements.")
-	listenAddress    = flag.String("web.listen-address", getEnv("REDIS_EXPORTER_WEB_LISTEN_ADDRESS", ":9121"), "Address to listen on for web interface and telemetry.")
-	metricPath       = flag.String("web.telemetry-path", getEnv("REDIS_EXPORTER_WEB_TELEMETRY_PATH", "/metrics"), "Path under which to expose metrics.")
-	isDebug          = flag.Bool("debug", getEnvBool("REDIS_EXPORTER_DEBUG"), "Output verbose debug information")
-	logFormat        = flag.String("log-format", getEnv("REDIS_EXPORTER_LOG_FORMAT", "txt"), "Log format, valid options are txt and json")
-	showVersion      = flag.Bool("version", false, "Show version information and exit")
-	useCfBindings    = flag.Bool("use-cf-bindings", getEnvBool("REDIS_EXPORTER_USE-CF-BINDINGS"), "Use Cloud Foundry service bindings")
-	redisMetricsOnly = flag.Bool("redis-only-metrics", getEnvBool("REDIS_EXPORTER_REDIS_ONLY_METRICS"), "Whether to export go runtime metrics also")
+	redisAddr         = flag.String("redis.addr", getEnv("REDIS_ADDR", ""), "Address of one or more redis nodes, separated by separator")
+	redisFile         = flag.String("redis.file", getEnv("REDIS_FILE", ""), "Path to file containing one or more redis nodes, separated by newline. NOTE: mutually exclusive with redis.addr")
+	redisPassword     = flag.String("redis.password", getEnv("REDIS_PASSWORD", ""), "Password for one or more redis nodes, separated by separator")
+	redisPasswordFile = flag.String("redis.password-file", getEnv("REDIS_PASSWORD_FILE", ""), "File containing the password for one or more redis nodes, separated by separator. NOTE: mutually exclusive with redis.password")
+	redisAlias        = flag.String("redis.alias", getEnv("REDIS_ALIAS", ""), "Redis instance alias for one or more redis nodes, separated by separator")
+	namespace         = flag.String("namespace", getEnv("REDIS_EXPORTER_NAMESPACE", "redis"), "Namespace for metrics")
+	checkKeys         = flag.String("check-keys", getEnv("REDIS_EXPORTER_CHECK_KEYS", ""), "Comma separated list of key-patterns to export value and length/size, searched for with SCAN")
+	checkSingleKeys   = flag.String("check-single-keys", getEnv("REDIS_EXPORTER_CHECK_SINGLE_KEYS", ""), "Comma separated list of single keys to export value and length/size")
+	scriptPath        = flag.String("script", getEnv("REDIS_EXPORTER_SCRIPT", ""), "Path to Lua Redis script for collecting extra metrics")
+	separator         = flag.String("separator", getEnv("REDIS_EXPORTER_SEPARATOR", ","), "separator used to split redis.addr, redis.password and redis.alias into several elements.")
+	listenAddress     = flag.String("web.listen-address", getEnv("REDIS_EXPORTER_WEB_LISTEN_ADDRESS", ":9121"), "Address to listen on for web interface and telemetry.")
+	metricPath        = flag.String("web.telemetry-path", getEnv("REDIS_EXPORTER_WEB_TELEMETRY_PATH", "/metrics"), "Path under which to expose metrics.")
+	isDebug           = flag.Bool("debug", getEnvBool("REDIS_EXPORTER_DEBUG"), "Output verbose debug information")
+	logFormat         = flag.String("log-format", getEnv("REDIS_EXPORTER_LOG_FORMAT", "txt"), "Log format, valid options are txt and json")
+	showVersion       = flag.Bool("version", false, "Show version information and exit")
+	useCfBindings     = flag.Bool("use-cf-bindings", getEnvBool("REDIS_EXPORTER_USE-CF-BINDINGS"), "Use Cloud Foundry service bindings")
+	redisMetricsOnly  = flag.Bool("redis-only-metrics", getEnvBool("REDIS_EXPORTER_REDIS_ONLY_METRICS"), "Whether to export go runtime metrics also")
 
 	// VERSION, BUILD_DATE, GIT_COMMIT are filled in by the build script
 	VERSION     = "<<< filled in by build >>>"
@@ -80,6 +81,21 @@ func main() {
 		log.Fatal("Cannot specify both redis.addr and redis.file")
 	}
 
+	var parsedRedisPassword string
+
+	if *redisPasswordFile != "" {
+		if *redisPassword != "" {
+			log.Fatal("Cannot specify both redis.password and redis.password-file")
+		}
+		b, err := ioutil.ReadFile(*redisPasswordFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		parsedRedisPassword = string(b)
+	} else {
+		parsedRedisPassword = *redisPassword
+	}
+
 	var addrs, passwords, aliases []string
 
 	switch {
@@ -92,7 +108,7 @@ func main() {
 	case *useCfBindings:
 		addrs, passwords, aliases = exporter.GetCloudFoundryRedisBindings()
 	default:
-		addrs, passwords, aliases = exporter.LoadRedisArgs(*redisAddr, *redisPassword, *redisAlias, *separator)
+		addrs, passwords, aliases = exporter.LoadRedisArgs(*redisAddr, parsedRedisPassword, *redisAlias, *separator)
 	}
 
 	exp, err := exporter.NewRedisExporter(


### PR DESCRIPTION
Signed-off-by: Javier J. Salmeron Garcia <jsalmeron@bitnami.com>

In some contexts, providing the password using REDIS_PASSWORD is not recommended, as this information could be potentially extracted by privileged containers that could execute commands like `docker inspect`. The same could be said to anyone that could access the kubelet host where the container is running. Because of this, some deployments require the ability to pass passwords as files. This PR enables this feature.

I set that REDIS_PASSWORD and REDIS_PASSWORD_FILE (the new variable that points to a file containing the password) to be mutually exclusive, so only one can be declared at the same time. This change does not break backwards compatibility.