### PR TITLE
Run as non-root user for secure environments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,5 +40,8 @@ FROM scratch as scratch
 COPY --from=builder /redis_exporter /redis_exporter
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 
+# Run as non-root user for secure environments
+USER 59000:59000
+
 EXPOSE     9121
 ENTRYPOINT [ "/redis_exporter" ]


### PR DESCRIPTION
I'm running this in a kubernetes environment where there's a pod security policy disallowing the use of non-root images.

The industry recommendation is typically to run as a numbered user to avoid conflicts with actual host users.

This PR sets the user and group to `59000` to be able to run in those conditions. 