### PR TITLE
Tile38 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
       - image: redis:5
         command: --port 6380
       - image: grokzen/redis-cluster
+      - image: tile38/tile38:latest
 
     working_directory: /go/src/github.com/oliver006/redis_exporter
     steps:

--- a/exporter/redis.go
+++ b/exporter/redis.go
@@ -896,10 +896,12 @@ func (e *Exporter) scrapeRedisHost(scrapes chan<- scrapeResult, addr string, idx
 
 	e.extractInfoMetrics(infoAll, addr, e.redis.Aliases[idx], scrapes, dbCount)
 
+	// SERVER command only works on tile38 database. check the following link to
+	// findout more: https://tile38.com/
 	if serverInfo, err := redis.Strings(doRedisCmd(c, "SERVER")); err == nil {
 		e.extractTile38Metrics(serverInfo, addr, e.redis.Aliases[idx], scrapes)
 	} else {
-		log.Errorf("Redis SERVER err: %s", err)
+		log.Debugf("Tile38 SERVER err: %s", err)
 	}
 
 	if reply, err := doRedisCmd(c, "LATENCY", "LATEST"); err == nil {

--- a/exporter/redis.go
+++ b/exporter/redis.go
@@ -277,7 +277,7 @@ func parseKeyArg(keysArgString string) (keys []dbKeyPair, err error) {
 
 // NewRedisExporter returns a new exporter of Redis metrics.
 // note to self: next time we add an argument, instead add a RedisExporter struct
-func NewRedisExporter(host RedisHost, namespace, checkSingleKeys, checkKeys string, isTile38 bool) (*Exporter, error) {
+func NewRedisExporter(host RedisHost, namespace, checkSingleKeys, checkKeys string) (*Exporter, error) {
 
 	e := Exporter{
 		redis:     host,
@@ -314,8 +314,6 @@ func NewRedisExporter(host RedisHost, namespace, checkSingleKeys, checkKeys stri
 		}),
 	}
 
-	e.isTile38 = isTile38
-
 	var err error
 
 	if e.keys, err = parseKeyArg(checkKeys); err != nil {
@@ -332,6 +330,16 @@ func NewRedisExporter(host RedisHost, namespace, checkSingleKeys, checkKeys stri
 
 	e.initGauges()
 	return &e, nil
+}
+
+// NewTile38Exporter returns a new exporter of Til38 metrics.
+func NewTile38Exporter(host RedisHost, namespace, checkSingleKeys, checkKeys string) (*Exporter, error) {
+	e, err := NewRedisExporter(host, namespace, checkSingleKeys, checkKeys)
+	if err != nil {
+		return nil, err
+	}
+	e.isTile38 = true
+	return e, nil
 }
 
 // Describe outputs Redis metric descriptions.

--- a/exporter/redis.go
+++ b/exporter/redis.go
@@ -145,7 +145,7 @@ var (
 		"aof_size":        "aof_size_bytes",
 		"avg_item_size":   "avg_item_size_bytes",
 		"cpus":            "cpus_total",
-		"heap_released":   "heap_released_byte",
+		"heap_released":   "heap_released_bytes",
 		"heap_size":       "heap_size_bytes",
 		"http_transport":  "http_transport",
 		"in_memory_size":  "in_memory_size_bytes",

--- a/exporter/redis.go
+++ b/exporter/redis.go
@@ -897,7 +897,7 @@ func (e *Exporter) scrapeRedisHost(scrapes chan<- scrapeResult, addr string, idx
 	e.extractInfoMetrics(infoAll, addr, e.redis.Aliases[idx], scrapes, dbCount)
 
 	// SERVER command only works on tile38 database. check the following link to
-	// findout more: https://tile38.com/
+	// find out more: https://tile38.com/
 	if serverInfo, err := redis.Strings(doRedisCmd(c, "SERVER")); err == nil {
 		e.extractTile38Metrics(serverInfo, addr, e.redis.Aliases[idx], scrapes)
 	} else {

--- a/exporter/redis.go
+++ b/exporter/redis.go
@@ -143,15 +143,24 @@ var (
 		"cluster_stats_messages_received": "cluster_messages_received_total",
 
 		// # Tile38
+		// based on https://tile38.com/commands/server/
 		"aof_size":        "aof_size_bytes",
 		"avg_item_size":   "avg_item_size_bytes",
-		"cpu":             "cpu_total",
+		"cpus":            "cpus_total",
+		"heap_released":   "heap_released_byte",
+		"heap_size":       "heap_size_bytes",
+		"http_transport":  "http_transport",
+		"in_memory_size":  "in_memory_size_bytes",
+		"max_heap_size":   "max_heap_size_bytes",
+		"mem_alloc":       "mem_alloc_bytes",
 		"num_collections": "num_collections_total",
+		"num_hooks":       "num_hooks_total",
 		"num_objects":     "num_objects_total",
 		"num_points":      "num_points_total",
-		"heap_size":       "heap_size_bytes",
-		"version":         "version", // since tile38 version 1.14.1
+		"pointer_size":    "pointer_size_bytes",
+		"read_only":       "read_only",
 		"threads":         "threads_total",
+		"version":         "version", // since tile38 version 1.14.1
 	}
 
 	instanceInfoFields = map[string]bool{"role": true, "redis_version": true, "redis_build_id": true, "redis_mode": true, "os": true}

--- a/exporter/redis_test.go
+++ b/exporter/redis_test.go
@@ -45,7 +45,7 @@ var (
 	listKeys         = []string{}
 	ts               = int32(time.Now().Unix())
 	defaultRedisHost = RedisHost{}
-	defaultTileHost  = RedisHost{Addrs: []string{":9851"}}
+	defaultTileHost  = RedisHost{Addrs: []string{":9851"}, Aliases: []string{"tile"}}
 
 	dbNumStr     = "11"
 	altDBNumStr  = "12"

--- a/exporter/redis_test.go
+++ b/exporter/redis_test.go
@@ -45,6 +45,7 @@ var (
 	listKeys         = []string{}
 	ts               = int32(time.Now().Unix())
 	defaultRedisHost = RedisHost{}
+	defaultTileHost  = RedisHost{Addrs: []string{":9851"}}
 
 	dbNumStr     = "11"
 	altDBNumStr  = "12"
@@ -211,6 +212,29 @@ func TestLatencySpike(t *testing.T) {
 				t.Errorf("latency threshold was not reset")
 			}
 		}
+	}
+}
+
+func TestTile38(t *testing.T) {
+	e, _ := NewRedisExporter(defaultTileHost, "test", "", "")
+
+	chM := make(chan prometheus.Metric)
+	go func() {
+		e.Collect(chM)
+		close(chM)
+	}()
+
+	find := false
+	for m := range chM {
+		switch m := m.(type) {
+		case prometheus.Gauge:
+			if strings.Contains(m.Desc().String(), "cpus_total") {
+				find = true
+			}
+		}
+	}
+	if !find {
+		t.Errorf("cpus_total was not found in tile38 metrics")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ var (
 	showVersion       = flag.Bool("version", false, "Show version information and exit")
 	useCfBindings     = flag.Bool("use-cf-bindings", getEnvBool("REDIS_EXPORTER_USE-CF-BINDINGS"), "Use Cloud Foundry service bindings")
 	redisMetricsOnly  = flag.Bool("redis-only-metrics", getEnvBool("REDIS_EXPORTER_REDIS_ONLY_METRICS"), "Whether to export go runtime metrics also")
+	isTile38          = flag.Bool("tile38", getEnvBool("REDIS_EXPORTER_TILE38"), "Assume that all nodes are tile38 nodes that are using redis protocol")
 
 	// VERSION, BUILD_DATE, GIT_COMMIT are filled in by the build script
 	VERSION     = "<<< filled in by build >>>"
@@ -116,6 +117,7 @@ func main() {
 		*namespace,
 		*checkSingleKeys,
 		*checkKeys,
+		*isTile38,
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -32,7 +32,6 @@ var (
 	showVersion       = flag.Bool("version", false, "Show version information and exit")
 	useCfBindings     = flag.Bool("use-cf-bindings", getEnvBool("REDIS_EXPORTER_USE-CF-BINDINGS"), "Use Cloud Foundry service bindings")
 	redisMetricsOnly  = flag.Bool("redis-only-metrics", getEnvBool("REDIS_EXPORTER_REDIS_ONLY_METRICS"), "Whether to export go runtime metrics also")
-	isTile38          = flag.Bool("tile38", getEnvBool("REDIS_EXPORTER_TILE38"), "Assume that all nodes are tile38 nodes that are using redis protocol")
 
 	// VERSION, BUILD_DATE, GIT_COMMIT are filled in by the build script
 	VERSION     = "<<< filled in by build >>>"
@@ -112,30 +111,14 @@ func main() {
 		addrs, passwords, aliases = exporter.LoadRedisArgs(*redisAddr, parsedRedisPassword, *redisAlias, *separator)
 	}
 
-	var exp *exporter.Exporter
-	if *isTile38 {
-		var err error
-		exp, err = exporter.NewTile38Exporter(
-			exporter.RedisHost{Addrs: addrs, Passwords: passwords, Aliases: aliases},
-			*namespace,
-			*checkSingleKeys,
-			*checkKeys,
-		)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-	} else {
-		var err error
-		exp, err = exporter.NewRedisExporter(
-			exporter.RedisHost{Addrs: addrs, Passwords: passwords, Aliases: aliases},
-			*namespace,
-			*checkSingleKeys,
-			*checkKeys,
-		)
-		if err != nil {
-			log.Fatal(err)
-		}
+	exp, err := exporter.NewRedisExporter(
+		exporter.RedisHost{Addrs: addrs, Passwords: passwords, Aliases: aliases},
+		*namespace,
+		*checkSingleKeys,
+		*checkKeys,
+	)
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	if *scriptPath != "" {

--- a/main.go
+++ b/main.go
@@ -112,15 +112,30 @@ func main() {
 		addrs, passwords, aliases = exporter.LoadRedisArgs(*redisAddr, parsedRedisPassword, *redisAlias, *separator)
 	}
 
-	exp, err := exporter.NewRedisExporter(
-		exporter.RedisHost{Addrs: addrs, Passwords: passwords, Aliases: aliases},
-		*namespace,
-		*checkSingleKeys,
-		*checkKeys,
-		*isTile38,
-	)
-	if err != nil {
-		log.Fatal(err)
+	var exp *exporter.Exporter
+	if *isTile38 {
+		var err error
+		exp, err = exporter.NewTile38Exporter(
+			exporter.RedisHost{Addrs: addrs, Passwords: passwords, Aliases: aliases},
+			*namespace,
+			*checkSingleKeys,
+			*checkKeys,
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+	} else {
+		var err error
+		exp, err = exporter.NewRedisExporter(
+			exporter.RedisHost{Addrs: addrs, Passwords: passwords, Aliases: aliases},
+			*namespace,
+			*checkSingleKeys,
+			*checkKeys,
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	if *scriptPath != "" {


### PR DESCRIPTION
[Tile38](https://github.com/tidwall/tile38) is a geospatial database that is using redis communication protocol and structure. I add a flag to support metric collection from tile38 databases. Tile38 offer a command named `Server` that is not available in `redis_exporter` and I add it with this PR.