### PR TITLE
Adding replication lag metric

### DIFF
--- a/exporter/redis.go
+++ b/exporter/redis.go
@@ -442,10 +442,15 @@ func parseConnectedSlaveString(slaveName string, slaveInfo string) (offset float
 		return
 	}
 
-	lag, err = strconv.ParseFloat(connectedSlaveInfo["lag"], 64)
-	if err != nil {
+	if lagStr, exists := connectedSlaveInfo["lag"]; exists == false {
 		// Prior to 3.0, "lag" property does not exist
 		lag = -1
+	} else {
+		lag, err = strconv.ParseFloat(lagStr, 64)
+		if err != nil {
+			log.Debugf("Can not parse connected slave lag, got: %s", lagStr)
+			return
+		}
 	}
 
 	ok = true

--- a/exporter/redis.go
+++ b/exporter/redis.go
@@ -173,6 +173,11 @@ func (e *Exporter) initGauges() {
 		Name:      "connected_slave_offset",
 		Help:      "Offset of connected slave",
 	}, []string{"addr", "alias", "slave_ip", "slave_port", "slave_state"})
+	e.metrics["connected_slave_lag_seconds"] = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: e.namespace,
+		Name:      "connected_slave_lag_seconds",
+		Help:      "Lag of connected slave",
+	}, []string{"addr", "alias", "slave_ip", "slave_port", "slave_state"})
 	e.metrics["db_keys"] = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: e.namespace,
 		Name:      "db_keys",
@@ -417,7 +422,7 @@ func parseDBKeyspaceString(db string, stats string) (keysTotal float64, keysExpi
 	slave0:ip=10.254.11.1,port=6379,state=online,offset=1751844676,lag=0
 	slave1:ip=10.254.11.2,port=6379,state=online,offset=1751844222,lag=0
 */
-func parseConnectedSlaveString(slaveName string, slaveInfo string) (offset float64, ip string, port string, state string, ok bool) {
+func parseConnectedSlaveString(slaveName string, slaveInfo string) (offset float64, ip string, port string, state string, lag float64, ok bool) {
 	ok = false
 	if matched, _ := regexp.MatchString(`^slave\d+`, slaveName); !matched {
 		return
@@ -436,6 +441,13 @@ func parseConnectedSlaveString(slaveName string, slaveInfo string) (offset float
 		log.Debugf("Can not parse connected slave offset, got: %s", connectedSlaveInfo["offset"])
 		return
 	}
+
+	lag, err = strconv.ParseFloat(connectedSlaveInfo["lag"], 64)
+	if err != nil {
+		log.Debugf("Can not parse connected slave lag, got: %s", connectedSlaveInfo["lag"])
+		return
+	}
+
 	ok = true
 	ip = connectedSlaveInfo["ip"]
 	port = connectedSlaveInfo["port"]
@@ -525,7 +537,7 @@ func (e *Exporter) extractInfoMetrics(info, addr string, alias string, scrapes c
 				continue
 			}
 
-			if slaveOffset, slaveIp, slavePort, slaveState, ok := parseConnectedSlaveString(fieldKey, fieldValue); ok {
+			if slaveOffset, slaveIp, slavePort, slaveState, lag, ok := parseConnectedSlaveString(fieldKey, fieldValue); ok {
 				e.metricsMtx.RLock()
 				e.metrics["connected_slave_offset"].WithLabelValues(
 					addr,
@@ -534,6 +546,13 @@ func (e *Exporter) extractInfoMetrics(info, addr string, alias string, scrapes c
 					slavePort,
 					slaveState,
 				).Set(slaveOffset)
+				e.metrics["connected_slave_lag_seconds"].WithLabelValues(
+					addr,
+					alias,
+					slaveIp,
+					slavePort,
+					slaveState,
+				).Set(lag)
 				e.metricsMtx.RUnlock()
 				continue
 			}

--- a/exporter/redis_test.go
+++ b/exporter/redis_test.go
@@ -550,29 +550,30 @@ type slaveData struct {
 	k, v            string
 	ip, state, port string
 	offset          float64
+	lag             float64
 	ok              bool
 }
 
 func TestParseConnectedSlaveString(t *testing.T) {
 	tsts := []slaveData{
-		{k: "slave0", v: "ip=10.254.11.1,port=6379,state=online,offset=1751844676,lag=0", offset: 1751844676, ip: "10.254.11.1", port: "6379", state: "online", ok: true},
-		{k: "slave1", v: "offset=1", offset: 1, ok: true},
-		{k: "slave2", v: "ip=1.2.3.4,state=online,offset=123", offset: 123, ip: "1.2.3.4", state: "online", ok: true},
-		{k: "slave", v: "offset=1751844676", ok: false},
-		{k: "slaveA", v: "offset=1751844676", ok: false},
-		{k: "slave0", v: "offset=abc", ok: false},
+		{k: "slave0", v: "ip=10.254.11.1,port=6379,state=online,offset=1751844676,lag=0", offset: 1751844676, ip: "10.254.11.1", port: "6379", state: "online", ok: true, lag: 0},
+		{k: "slave1", v: "offset=1,lag=0", offset: 1, ok: true},
+		{k: "slave2", v: "ip=1.2.3.4,state=online,offset=123,lag=42", offset: 123, ip: "1.2.3.4", state: "online", ok: true, lag: 42},
+		{k: "slave", v: "offset=1751844676,lag=0", ok: false},
+		{k: "slaveA", v: "offset=1751844676,lag=0", ok: false},
+		{k: "slave0", v: "offset=abc,lag=0", ok: false},
 	}
 
 	for _, tst := range tsts {
-		if offset, ip, port, state, ok := parseConnectedSlaveString(tst.k, tst.v); true {
+		if offset, ip, port, state, lag, ok := parseConnectedSlaveString(tst.k, tst.v); true {
 
 			if ok != tst.ok {
 				t.Errorf("failed for: db:%s stats:%s", tst.k, tst.v)
 				continue
 			}
 
-			if offset != tst.offset || ip != tst.ip || port != tst.port || state != tst.state {
-				t.Errorf("values not matching, string:%s %f %s %s %s", tst.v, offset, ip, port, state)
+			if offset != tst.offset || ip != tst.ip || port != tst.port || state != tst.state || lag != tst.lag {
+				t.Errorf("values not matching, string:%s %f %s %s %s %f", tst.v, offset, ip, port, state, lag)
 			}
 		}
 	}

--- a/exporter/redis_test.go
+++ b/exporter/redis_test.go
@@ -563,6 +563,7 @@ func TestParseConnectedSlaveString(t *testing.T) {
 		{k: "slaveA", v: "offset=1751844676,lag=0", ok: false},
 		{k: "slave0", v: "offset=abc,lag=0", ok: false},
 		{k: "slave0", v: "offset=0,lag=abc", ok: false},
+		{k: "slave0", v: "offset=0", ok: false, lag: -1},
 	}
 
 	for _, tst := range tsts {

--- a/exporter/redis_test.go
+++ b/exporter/redis_test.go
@@ -562,6 +562,7 @@ func TestParseConnectedSlaveString(t *testing.T) {
 		{k: "slave", v: "offset=1751844676,lag=0", ok: false},
 		{k: "slaveA", v: "offset=1751844676,lag=0", ok: false},
 		{k: "slave0", v: "offset=abc,lag=0", ok: false},
+		{k: "slave0", v: "offset=0,lag=abc", ok: false},
 	}
 
 	for _, tst := range tsts {

--- a/exporter/redis_test.go
+++ b/exporter/redis_test.go
@@ -558,12 +558,12 @@ func TestParseConnectedSlaveString(t *testing.T) {
 	tsts := []slaveData{
 		{k: "slave0", v: "ip=10.254.11.1,port=6379,state=online,offset=1751844676,lag=0", offset: 1751844676, ip: "10.254.11.1", port: "6379", state: "online", ok: true, lag: 0},
 		{k: "slave1", v: "offset=1,lag=0", offset: 1, ok: true},
+		{k: "slave1", v: "offset=1", offset: 1, ok: true, lag: -1},
 		{k: "slave2", v: "ip=1.2.3.4,state=online,offset=123,lag=42", offset: 123, ip: "1.2.3.4", state: "online", ok: true, lag: 42},
 		{k: "slave", v: "offset=1751844676,lag=0", ok: false},
 		{k: "slaveA", v: "offset=1751844676,lag=0", ok: false},
 		{k: "slave0", v: "offset=abc,lag=0", ok: false},
 		{k: "slave0", v: "offset=0,lag=abc", ok: false},
-		{k: "slave0", v: "offset=0", ok: false, lag: -1},
 	}
 
 	for _, tst := range tsts {


### PR DESCRIPTION
Adding a new metric for measuring replication lag.

```
# HELP redis_connected_slave_lag_seconds Lag of connected slave
# TYPE redis_connected_slave_lag_seconds gauge
redis_connected_slave_lag_seconds{addr="**********",alias="",slave_ip="********",slave_port="6379",slave_state="online"} 1
```