### PR TITLE
For redis 2.4 the INFO command should be passed without arguments.

### DIFF
--- a/exporter/redis.go
+++ b/exporter/redis.go
@@ -911,7 +911,7 @@ func (e *Exporter) scrapeRedisHost(scrapes chan<- scrapeResult, addr string, idx
 
 	infoAll, err := redis.String(doRedisCmd(c, "INFO", "ALL"))
 	if err != nil {
-		infoAll, err = redis.String(doRedisCmd(c, "INFO", ""))
+		infoAll, err = redis.String(doRedisCmd(c, "INFO"))
 		if err != nil {
 			log.Errorf("Redis INFO err: %s", err)
 			return err

--- a/exporter/redis.go
+++ b/exporter/redis.go
@@ -911,8 +911,11 @@ func (e *Exporter) scrapeRedisHost(scrapes chan<- scrapeResult, addr string, idx
 
 	infoAll, err := redis.String(doRedisCmd(c, "INFO", "ALL"))
 	if err != nil {
-		log.Errorf("Redis INFO err: %s", err)
-		return err
+		infoAll, err = redis.String(doRedisCmd(c, "INFO", ""))
+		if err != nil {
+			log.Errorf("Redis INFO err: %s", err)
+			return err
+		}
 	}
 	isClusterEnabled := strings.Contains(infoAll, "cluster_enabled:1")
 


### PR DESCRIPTION
When running the redis exporter with redis 2.4 there's an error running the INFO command, since it doesn't accept the ALL parameter. The proposed fix is to run INFO without arguments if INFO ALL fails.