### PR TITLE
Make grafana dashboard import ask for datasource

### DIFF
--- a/contrib/grafana_prometheus_redis_dashboard.json
+++ b/contrib/grafana_prometheus_redis_dashboard.json
@@ -1,4 +1,40 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROM",
+      "label": "prom",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "singlestat",
+      "name": "Singlestat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "3.1.1"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -29,7 +65,7 @@
         "rgba(237, 129, 40, 0.89)",
         "rgba(50, 172, 45, 0.97)"
       ],
-      "datasource": "prom",
+      "datasource": "${DS_PROM}",
       "decimals": 0,
       "editable": true,
       "error": false,
@@ -117,7 +153,7 @@
         "rgba(237, 129, 40, 0.89)",
         "rgba(50, 172, 45, 0.97)"
       ],
-      "datasource": "prom",
+      "datasource": "${DS_PROM}",
       "decimals": 0,
       "editable": true,
       "error": false,
@@ -207,7 +243,7 @@
         "rgba(237, 129, 40, 0.89)",
         "rgba(245, 54, 54, 0.9)"
       ],
-      "datasource": "prom",
+      "datasource": "${DS_PROM}",
       "decimals": 0,
       "editable": true,
       "error": false,
@@ -293,7 +329,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "prom",
+      "datasource": "${DS_PROM}",
       "editable": true,
       "error": false,
       "fill": 1,
@@ -387,7 +423,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "prom",
+      "datasource": "${DS_PROM}",
       "decimals": 2,
       "editable": true,
       "error": false,
@@ -497,7 +533,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "prom",
+      "datasource": "${DS_PROM}",
       "editable": true,
       "error": false,
       "fill": 1,
@@ -601,7 +637,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "prom",
+      "datasource": "${DS_PROM}",
       "editable": true,
       "error": false,
       "fill": 1,
@@ -701,7 +737,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "prom",
+      "datasource": "${DS_PROM}",
       "editable": true,
       "error": false,
       "fill": 7,
@@ -796,7 +832,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "prom",
+      "datasource": "${DS_PROM}",
       "editable": true,
       "error": false,
       "fill": 7,
@@ -903,7 +939,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "prom",
+      "datasource": "${DS_PROM}",
       "editable": true,
       "error": false,
       "fill": 1,
@@ -1012,7 +1048,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "prom",
+      "datasource": "${DS_PROM}",
       "editable": true,
       "error": false,
       "fill": 8,
@@ -1112,11 +1148,8 @@
     "list": [
       {
         "allValue": null,
-        "current": {
-          "text": "fbrss.nbg1.ex.ohardt.net:9121",
-          "value": "fbrss.nbg1.ex.ohardt.net:9121"
-        },
-        "datasource": "prom",
+        "current": {},
+        "datasource": "${DS_PROM}",
         "definition": "label_values(redis_up, instance)",
         "hide": 0,
         "includeAll": false,
@@ -1168,6 +1201,5 @@
   },
   "timezone": "browser",
   "title": "Prometheus Redis for Redis Exporter 1.0.0",
-  "uid": "tRX1IOmWz",
-  "version": 11
+  "version": 12
 }


### PR DESCRIPTION
This was lost in the 1.0.0 version when compared to `contrib/grafana_prometheus_redis_dashboard_exporter_version_0.3x.json`.

Thanks for an awesome exporter + dashboard :)