### PR TITLE
Added client list details to use with PromQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ web.telemetry-path     | REDIS_EXPORTER_WEB_TELEMETRY_PATH    | Path under which
 redis-only-metrics     | REDIS_EXPORTER_REDIS_ONLY_METRICS    | Whether to also export go runtime metrics, defaults to false.
 include-system-metrics | REDIS_EXPORTER_INCL_SYSTEM_METRICS   | Whether to include system metrics like `total_system_memory_bytes`, defaults to false.
 is-tile38              | REDIS_EXPORTER_IS_TILE38             | Whether to scrape Tile38 specific metrics, defaults to false.
-export-client-list     | REDIS_EXPORTER_EXPORT_CLIENT_LIST    | Whether to scrape Client List specific metrics
+export-client-list     | REDIS_EXPORTER_EXPORT_CLIENT_LIST    | Whether to scrape Client List specific metrics, defaults to false.
 skip-tls-verification  | REDIS_EXPORTER_SKIP_TLS_VERIFICATION | Whether to to skip TLS verification
 tls-client-key-file    | REDIS_EXPORTER_TLS_CLIENT_KEY_FILE   | Name of the client key file (including full path) if the server requires TLS client authentication
 tls-client-cert-file   | REDIS_EXPORTER_TLS_CLIENT_CERT_FILE  | Name the client cert file (including full path) if the server requires TLS client authentication

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ web.telemetry-path     | REDIS_EXPORTER_WEB_TELEMETRY_PATH    | Path under which
 redis-only-metrics     | REDIS_EXPORTER_REDIS_ONLY_METRICS    | Whether to also export go runtime metrics, defaults to false.
 include-system-metrics | REDIS_EXPORTER_INCL_SYSTEM_METRICS   | Whether to include system metrics like `total_system_memory_bytes`, defaults to false.
 is-tile38              | REDIS_EXPORTER_IS_TILE38             | Whether to scrape Tile38 specific metrics, defaults to false.
+export-client-list     | REDIS_EXPORTER_EXPORT_CLIENT_LIST    | Whether to scrape Client List specific metrics
 skip-tls-verification  | REDIS_EXPORTER_SKIP_TLS_VERIFICATION | Whether to to skip TLS verification
 tls-client-key-file    | REDIS_EXPORTER_TLS_CLIENT_KEY_FILE   | Name of the client key file (including full path) if the server requires TLS client authentication
 tls-client-cert-file   | REDIS_EXPORTER_TLS_CLIENT_CERT_FILE  | Name the client cert file (including full path) if the server requires TLS client authentication

--- a/exporter.go
+++ b/exporter.go
@@ -306,7 +306,7 @@ func NewRedisExporter(redisURI string, opts ExporterOptions) (*Exporter, error) 
 		"slowlog_length":                       {txt: `Total slowlog`},
 		"start_time_seconds":                   {txt: "Start time of the Redis instance since unix epoch in seconds."},
 		"up":                                   {txt: "Information about the Redis instance"},
-		"connected_clients_details":            {txt: "Details about connected clients", lbls: []string{"host", "port", "name", "fd", "age", "idle", "flags", "db", "sub", "psub", "multi", "qbuf", "qbuffree", "obl", "oll", "omem", "events", "cmd"}},
+		"connected_clients_details":            {txt: "Details about connected clients", lbls: []string{"host", "port", "name", "age", "idle", "flags", "db", "cmd"}},
 	} {
 		e.metricDescriptions[k] = newMetricDescr(opts.Namespace, k, desc.txt, desc.lbls)
 	}
@@ -392,7 +392,7 @@ func extractVal(s string) (val float64, err error) {
 	id=11 addr=127.0.0.1:63508 fd=8 name= age=6321 idle=6320 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=setex
 	id=14 addr=127.0.0.1:64958 fd=9 name= age=5 idle=0 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=26 qbuf-free=32742 obl=0 oll=0 omem=0 events=r cmd=client
 */
-func parseClientListString(clientInfo string) (id float64, host string, port string, fd string, name string, age string, idle string, flags string, db string, sub string, psub string, multi string, qbuf string, qbuffree string, obl string, oll string, omem string, events string, cmd string, ok bool) {
+func parseClientListString(clientInfo string) (id float64, host string, port string, name string, age string, idle string, flags string, db string, cmd string, ok bool) {
 	var err error
 	ok = false
 	if matched, _ := regexp.MatchString(`^id=\d+ addr=\d+`, clientInfo); !matched {
@@ -418,22 +418,11 @@ func parseClientListString(clientInfo string) (id float64, host string, port str
 	host = hostPortString[0]
 	port = hostPortString[1]
 
-	fd = connectedClient["fd"]
 	name = connectedClient["name"]
 	age = connectedClient["age"]
 	idle = connectedClient["idle"]
 	flags = connectedClient["flags"]
 	db = connectedClient["db"]
-	sub = connectedClient["sub"]
-	multi = connectedClient["multi"]
-	psub = connectedClient["psub"]
-	qbuf = connectedClient["qbuf"]
-	qbuffree = connectedClient["qbuffree"]
-	obl = connectedClient["obl"]
-	oll = connectedClient["oll"]
-	omem = connectedClient["omem"]
-	events = connectedClient["events"]
-	cmd = connectedClient["cmd"]
 
 	ok = true
 	return
@@ -877,9 +866,9 @@ func (e *Exporter) extractConnectedClientMetrics(ch chan<- prometheus.Metric, c 
 	if reply, err := redis.String(doRedisCmd(c, "CLIENT", "LIST")); err == nil {
 		clients := strings.Split(reply, "\n")
 
-		for i := 0; i < len(clients)-1; i++ {
-			if id, host, port, fd, name, age, idle, flags, db, sub, psub, multi, qbuf, qbuffree, obl, oll, omem, events, cmd, ok := parseClientListString(clients[i]); ok {
-				e.registerConstMetricGauge(ch, "connected_clients_details", id, host, port, fd, name, age, idle, flags, db, sub, psub, multi, qbuf, qbuffree, obl, oll, omem, events, cmd)
+		for _, c := range clients {
+			if id, host, port, name, age, idle, flags, db, cmd, ok := parseClientListString(c); ok {
+				e.registerConstMetricGauge(ch, "connected_clients_details", id, host, port, name, age, idle, flags, db, cmd)
 			}
 		}
 	}

--- a/exporter.go
+++ b/exporter.go
@@ -163,7 +163,7 @@ func NewRedisExporter(redisURI string, opts ExporterOptions) (*Exporter, error) 
 			"process_id":        "process_id",
 
 			// # Clients
-			// "connected_clients":          "connected_clients",
+			"connected_clients":          "connected_clients",
 			"client_longest_output_list": "client_longest_output_list",
 			"client_biggest_input_buf":   "client_biggest_input_buf",
 			"blocked_clients":            "blocked_clients",
@@ -306,7 +306,7 @@ func NewRedisExporter(redisURI string, opts ExporterOptions) (*Exporter, error) 
 		"slowlog_length":                       {txt: `Total slowlog`},
 		"start_time_seconds":                   {txt: "Start time of the Redis instance since unix epoch in seconds."},
 		"up":                                   {txt: "Information about the Redis instance"},
-		"connected_clients":                    {txt: "Total number of connected clients", lbls: []string{"host", "port", "name", "age", "idle", "flags", "qbuf", "qbuffree", "cmd" }},
+		"connected_clients_details":            {txt: "Total number of connected clients", lbls: []string{"host", "port", "name", "age", "idle", "flags", "qbuf", "qbuffree", "cmd" }},
 	} {
 		e.metricDescriptions[k] = newMetricDescr(opts.Namespace, k, desc.txt, desc.lbls)
 	}
@@ -868,7 +868,7 @@ func (e *Exporter) extractConnectedClientMetrics(ch chan<- prometheus.Metric, c 
 		}
 
 		for name, count := range clientsMap {
-			e.registerConstMetricGauge(ch, "connected_clients", float64(count), name)
+			e.registerConstMetricGauge(ch, "connected_clients_details", float64(count), name)
 		}
 	}
 }

--- a/exporter.go
+++ b/exporter.go
@@ -423,6 +423,7 @@ func parseClientListString(clientInfo string) (id float64, host string, port str
 	idle = connectedClient["idle"]
 	flags = connectedClient["flags"]
 	db = connectedClient["db"]
+	cmd = connectedClient["cmd"]
 
 	ok = true
 	return

--- a/exporter.go
+++ b/exporter.go
@@ -306,7 +306,7 @@ func NewRedisExporter(redisURI string, opts ExporterOptions) (*Exporter, error) 
 		"slowlog_length":                       {txt: `Total slowlog`},
 		"start_time_seconds":                   {txt: "Start time of the Redis instance since unix epoch in seconds."},
 		"up":                                   {txt: "Information about the Redis instance"},
-		"connected_clients_details":            {txt: "Total number of connected clients", lbls: []string{"host", "port", "name", "age", "idle", "flags", "qbuf", "qbuffree", "cmd" }},
+		"connected_clients_details":            {txt: "Details about connected clients", lbls: []string{"host", "port", "name", "age", "idle", "flags", "qbuf", "qbuffree", "cmd"}},
 	} {
 		e.metricDescriptions[k] = newMetricDescr(opts.Namespace, k, desc.txt, desc.lbls)
 	}
@@ -392,7 +392,8 @@ func extractVal(s string) (val float64, err error) {
 	id=11 addr=127.0.0.1:63508 fd=8 name= age=6321 idle=6320 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=setex
 	id=14 addr=127.0.0.1:64958 fd=9 name= age=5 idle=0 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=26 qbuf-free=32742 obl=0 oll=0 omem=0 events=r cmd=client
 */
-func parseClientListString(clientInfo string) (host string, port string, name string, age string, idle string, flags string, qbuf string, qbuffree string, cmd string, ok bool) {
+func parseClientListString(clientInfo string) (id float64, host string, port string, fd string, name string, age string, idle string, flags string, db string, sub string, psub string, multi string, qbuf string, qbuffree string, obl string, omem string, events string, cmd string, ok bool) {
+	var err error
 	ok = false
 	if matched, _ := regexp.MatchString(`^id=\d+ addr=\d+`, clientInfo); !matched {
 		return
@@ -407,15 +408,30 @@ func parseClientListString(clientInfo string) (host string, port string, name st
 		connectedClient[vPart[0]] = vPart[1]
 	}
 
+	if id, err = strconv.ParseFloat(connectedClient["id"], 64); err != nil {
+		return
+	}
 	hostPortString := strings.Split(connectedClient["addr"], ":")
+	if len(hostPortString) != 2 {
+		return
+	}
 	host = hostPortString[0]
 	port = hostPortString[1]
+
+	fd = connectedClient["fd"]
 	name = connectedClient["name"]
 	age = connectedClient["age"]
 	idle = connectedClient["idle"]
 	flags = connectedClient["flags"]
+	db = connectedClient["db"]
+	sub = connectedClient["sub"]
+	multi = connectedClient["multi"]
+	psub = connectedClient["psub"]
 	qbuf = connectedClient["qbuf"]
 	qbuffree = connectedClient["qbuffree"]
+	obl = connectedClient["obl"]
+	omem = connectedClient["omem"]
+	events = connectedClient["events"]
 	cmd = connectedClient["cmd"]
 
 	ok = true
@@ -860,15 +876,10 @@ func (e *Exporter) extractConnectedClientMetrics(ch chan<- prometheus.Metric, c 
 	if reply, err := redis.String(doRedisCmd(c, "CLIENT", "LIST")); err == nil {
 		clients := strings.Split(reply, "\n")
 		
-		var clientsMap = map[string]int{}
-		for i := 0; i < len(clients) - 1; i++ {
-			if _, _, name, _, _, _, _, _, _, ok := parseClientListString(clients[i]); ok {
-				clientsMap[name]++
+		for i := 0; i < len(clients)-1; i++ {
+			if id, host, port, fd, name, age, idle, flags, db, sub, psub, multi, qbuf, qbuffree, obl, omem, events, cmd, ok := parseClientListString(clients[i]); ok {
+				e.registerConstMetricGauge(ch, "connected_clients_details", id, host, port, fd, name, age, idle, flags, db, sub, psub, multi, qbuf, qbuffree, obl, omem, events, cmd)
 			}
-		}
-
-		for name, count := range clientsMap {
-			e.registerConstMetricGauge(ch, "connected_clients_details", float64(count), name)
 		}
 	}
 }

--- a/exporter.go
+++ b/exporter.go
@@ -59,7 +59,7 @@ type ExporterOptions struct {
 	InclSystemMetrics   bool
 	SkipTLSVerification bool
 	IsTile38            bool
-	IsClientList		bool
+	IsClientList        bool
 	ConnectionTimeouts  time.Duration
 }
 

--- a/exporter.go
+++ b/exporter.go
@@ -59,7 +59,7 @@ type ExporterOptions struct {
 	InclSystemMetrics   bool
 	SkipTLSVerification bool
 	IsTile38            bool
-	IsClientList        bool
+	ExportClientList    bool
 	ConnectionTimeouts  time.Duration
 }
 
@@ -1083,7 +1083,7 @@ func (e *Exporter) scrapeRedisHost(ch chan<- prometheus.Metric) error {
 
 	e.extractSlowLogMetrics(ch, c)
 
-	if e.options.IsClientList {
+	if e.options.ExportClientList {
 		e.extractConnectedClientMetrics(ch, c)
 	}
 

--- a/exporter.go
+++ b/exporter.go
@@ -392,8 +392,7 @@ func extractVal(s string) (val float64, err error) {
 	id=11 addr=127.0.0.1:63508 fd=8 name= age=6321 idle=6320 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=setex
 	id=14 addr=127.0.0.1:64958 fd=9 name= age=5 idle=0 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=26 qbuf-free=32742 obl=0 oll=0 omem=0 events=r cmd=client
 */
-func parseClientListString(clientInfo string) (id float64, host string, port string, name string, age string, idle string, flags string, db string, cmd string, ok bool) {
-	var err error
+func parseClientListString(clientInfo string) (host string, port string, name string, age string, idle string, flags string, db string, cmd string, ok bool) {
 	ok = false
 	if matched, _ := regexp.MatchString(`^id=\d+ addr=\d+`, clientInfo); !matched {
 		return
@@ -408,9 +407,6 @@ func parseClientListString(clientInfo string) (id float64, host string, port str
 		connectedClient[vPart[0]] = vPart[1]
 	}
 
-	if id, err = strconv.ParseFloat(connectedClient["id"], 64); err != nil {
-		return
-	}
 	hostPortString := strings.Split(connectedClient["addr"], ":")
 	if len(hostPortString) != 2 {
 		return
@@ -868,8 +864,8 @@ func (e *Exporter) extractConnectedClientMetrics(ch chan<- prometheus.Metric, c 
 		clients := strings.Split(reply, "\n")
 
 		for _, c := range clients {
-			if id, host, port, name, age, idle, flags, db, cmd, ok := parseClientListString(c); ok {
-				e.registerConstMetricGauge(ch, "connected_clients_details", id, host, port, name, age, idle, flags, db, cmd)
+			if host, port, name, age, idle, flags, db, cmd, ok := parseClientListString(c); ok {
+				e.registerConstMetricGauge(ch, "connected_clients_details", 1.0, host, port, name, age, idle, flags, db, cmd)
 			}
 		}
 	}

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -239,13 +239,8 @@ func TestTile38(t *testing.T) {
 }
 
 func TestExportClientList(t *testing.T) {
-	if os.Getenv("TEST_EXPORT_CLIENT_LIST") == "" {
-		t.Skipf("TEST_EXPORT_CLIENT_LIST not set - skipping")
-	}
-
 	for _, isExportClientList := range []bool{true, false} {
-		e, _ := NewRedisExporter(os.Getenv("TEST_EXPORT_CLIENT_LIST"), ExporterOptions{Namespace: "test", ExportClientList: isExportClientList})
-
+		e := getTestExporter()
 		chM := make(chan prometheus.Metric)
 		go func() {
 			e.Collect(chM)
@@ -254,16 +249,16 @@ func TestExportClientList(t *testing.T) {
 
 		found := false
 		for m := range chM {
-			if strings.Contains(m.Desc().String(), "connected_clients") {
+			if strings.Contains(m.Desc().String(), "connected_clients_details") {
 				found = true
 				break
 			}
 		}
 
 		if isExportClientList && !found {
-			t.Errorf("connected_clients was *not* found in isExportClientList metrics but expected")
+			t.Errorf("connected_clients_details was *not* found in isExportClientList metrics but expected")
 		} else if !isExportClientList && found {
-			t.Errorf("connected_clients was *found* in isExportClientList metrics but *not* expected")
+			t.Errorf("connected_clients_details was *found* in isExportClientList metrics but *not* expected")
 		}
 	}
 }

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -241,6 +241,8 @@ func TestTile38(t *testing.T) {
 func TestExportClientList(t *testing.T) {
 	for _, isExportClientList := range []bool{true, false} {
 		e := getTestExporter()
+		e.options.ExportClientList = isExportClientList
+
 		chM := make(chan prometheus.Metric)
 		go func() {
 			e.Collect(chM)

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func main() {
 		tlsClientCertFile   = flag.String("tls-client-cert-file", getEnv("REDIS_EXPORTER_TLS_CLIENT_CERT_FILE", ""), "Name of the client certificate file (including full path) if the server requires TLS client authentication")
 		isDebug             = flag.Bool("debug", getEnvBool("REDIS_EXPORTER_DEBUG"), "Output verbose debug information")
 		isTile38            = flag.Bool("is-tile38", getEnvBool("REDIS_EXPORTER_IS_TILE38"), "Whether to scrape Tile38 specific metrics")
-		isClientList        = flag.Bool("is-client-list", getEnvBool("REDIS_EXPORTER_IS_CLIENT_LIST"), "Whether to scrape Client List specific metrics")
+		exportClientList    = flag.Bool("export-client-list", getEnvBool("REDIS_EXPORTER_EXPORT_CLIENT_LIST"), "Whether to scrape Client List specific metrics")
 		showVersion         = flag.Bool("version", false, "Show version information and exit")
 		redisMetricsOnly    = flag.Bool("redis-only-metrics", getEnvBool("REDIS_EXPORTER_REDIS_ONLY_METRICS"), "Whether to also export go runtime metrics")
 		inclSystemMetrics   = flag.Bool("include-system-metrics", getEnvBool("REDIS_EXPORTER_INCL_SYSTEM_METRICS"), "Whether to include system metrics like e.g. redis_total_system_memory_bytes")
@@ -109,7 +109,7 @@ func main() {
 			CheckSingleKeys:     *checkSingleKeys,
 			InclSystemMetrics:   *inclSystemMetrics,
 			IsTile38:            *isTile38,
-			IsClientList:        *isClientList,
+			ExportClientList:    *exportClientList,
 			SkipTLSVerification: *skipTLSVerification,
 			ClientCertificates:  tlsClientCertificates,
 			ConnectionTimeouts:  to,

--- a/main.go
+++ b/main.go
@@ -53,6 +53,7 @@ func main() {
 		tlsClientCertFile   = flag.String("tls-client-cert-file", getEnv("REDIS_EXPORTER_TLS_CLIENT_CERT_FILE", ""), "Name of the client certificate file (including full path) if the server requires TLS client authentication")
 		isDebug             = flag.Bool("debug", getEnvBool("REDIS_EXPORTER_DEBUG"), "Output verbose debug information")
 		isTile38            = flag.Bool("is-tile38", getEnvBool("REDIS_EXPORTER_IS_TILE38"), "Whether to scrape Tile38 specific metrics")
+		isClientList        = flag.Bool("is-client-list", getEnvBool("REDIS_EXPORTER_IS_CLIENTLIST"), "Whether to scrape Client List specific metrics")
 		showVersion         = flag.Bool("version", false, "Show version information and exit")
 		redisMetricsOnly    = flag.Bool("redis-only-metrics", getEnvBool("REDIS_EXPORTER_REDIS_ONLY_METRICS"), "Whether to also export go runtime metrics")
 		inclSystemMetrics   = flag.Bool("include-system-metrics", getEnvBool("REDIS_EXPORTER_INCL_SYSTEM_METRICS"), "Whether to include system metrics like e.g. redis_total_system_memory_bytes")
@@ -108,6 +109,7 @@ func main() {
 			CheckSingleKeys:     *checkSingleKeys,
 			InclSystemMetrics:   *inclSystemMetrics,
 			IsTile38:            *isTile38,
+			IsClientList:        *isClientList,
 			SkipTLSVerification: *skipTLSVerification,
 			ClientCertificates:  tlsClientCertificates,
 			ConnectionTimeouts:  to,

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func main() {
 		tlsClientCertFile   = flag.String("tls-client-cert-file", getEnv("REDIS_EXPORTER_TLS_CLIENT_CERT_FILE", ""), "Name of the client certificate file (including full path) if the server requires TLS client authentication")
 		isDebug             = flag.Bool("debug", getEnvBool("REDIS_EXPORTER_DEBUG"), "Output verbose debug information")
 		isTile38            = flag.Bool("is-tile38", getEnvBool("REDIS_EXPORTER_IS_TILE38"), "Whether to scrape Tile38 specific metrics")
-		isClientList        = flag.Bool("is-client-list", getEnvBool("REDIS_EXPORTER_IS_CLIENTLIST"), "Whether to scrape Client List specific metrics")
+		isClientList        = flag.Bool("is-client-list", getEnvBool("REDIS_EXPORTER_IS_CLIENT_LIST"), "Whether to scrape Client List specific metrics")
 		showVersion         = flag.Bool("version", false, "Show version information and exit")
 		redisMetricsOnly    = flag.Bool("redis-only-metrics", getEnvBool("REDIS_EXPORTER_REDIS_ONLY_METRICS"), "Whether to also export go runtime metrics")
 		inclSystemMetrics   = flag.Bool("include-system-metrics", getEnvBool("REDIS_EXPORTER_INCL_SYSTEM_METRICS"), "Whether to include system metrics like e.g. redis_total_system_memory_bytes")


### PR DESCRIPTION
I added a function to add CLIENT LIST stats that are group by client name in order to get a count of each client connected instead of just the total.

Please feel free to improve this push request and also please give me your opinion on how it can be improved in order to provide more labels to make this more flexible