### PR TITLE
Make latency spike duration metrics accurately reflect data

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -310,6 +310,7 @@ func NewRedisExporter(redisURI string, opts ExporterOptions) (*Exporter, error) 
 		"key_value":                            {txt: `The value of "key"`, lbls: []string{"db", "key"}},
 		"last_slow_execution_duration_seconds": {txt: `The amount of time needed for last slow execution, in seconds`},
 		"latency_spike_last":                   {txt: `When the latency spike last occurred`, lbls: []string{"event_name"}},
+		"latency_spike_timestamp_seconds":      {txt: `Length of the last latency spike in seconds`, lbls: []string{"event_name"}},
 		"latency_spike_milliseconds":           {txt: `Length of the last latency spike in milliseconds`, lbls: []string{"event_name"}},
 		"master_link_up":                       {txt: "Master link status on Redis slave"},
 		"script_values":                        {txt: "Values returned by the collect script", lbls: []string{"key"}},
@@ -886,7 +887,9 @@ func (e *Exporter) extractLatencyMetrics(ch chan<- prometheus.Metric, c redis.Co
 			latencyResult := tempVal[0].([]interface{})
 			var spikeLast, spikeDuration, max int64
 			if _, err := redis.Scan(latencyResult, &eventName, &spikeLast, &spikeDuration, &max); err == nil {
+				spikeDurationSeconds := float64(spikeDuration) / 1e3
 				e.registerConstMetricGauge(ch, "latency_spike_last", float64(spikeLast), eventName)
+				e.registerConstMetricGauge(ch, "latency_spike_timestamp_seconds", spikeDurationSeconds, eventName)
 				e.registerConstMetricGauge(ch, "latency_spike_milliseconds", float64(spikeDuration), eventName)
 			}
 		}

--- a/exporter.go
+++ b/exporter.go
@@ -310,8 +310,7 @@ func NewRedisExporter(redisURI string, opts ExporterOptions) (*Exporter, error) 
 		"key_value":                            {txt: `The value of "key"`, lbls: []string{"db", "key"}},
 		"last_slow_execution_duration_seconds": {txt: `The amount of time needed for last slow execution, in seconds`},
 		"latency_spike_last":                   {txt: `When the latency spike last occurred`, lbls: []string{"event_name"}},
-		"latency_spike_timestamp_seconds":      {txt: `Length of the last latency spike in seconds`, lbls: []string{"event_name"}},
-		"latency_spike_milliseconds":           {txt: `Length of the last latency spike in milliseconds`, lbls: []string{"event_name"}},
+		"latency_spike_duration_seconds":       {txt: `Length of the last latency spike in seconds`, lbls: []string{"event_name"}},
 		"master_link_up":                       {txt: "Master link status on Redis slave"},
 		"script_values":                        {txt: "Values returned by the collect script", lbls: []string{"key"}},
 		"slave_info":                           {txt: "Information about the Redis slave", lbls: []string{"master_host", "master_port", "read_only"}},
@@ -889,8 +888,7 @@ func (e *Exporter) extractLatencyMetrics(ch chan<- prometheus.Metric, c redis.Co
 			if _, err := redis.Scan(latencyResult, &eventName, &spikeLast, &spikeDuration, &max); err == nil {
 				spikeDurationSeconds := float64(spikeDuration) / 1e3
 				e.registerConstMetricGauge(ch, "latency_spike_last", float64(spikeLast), eventName)
-				e.registerConstMetricGauge(ch, "latency_spike_timestamp_seconds", spikeDurationSeconds, eventName)
-				e.registerConstMetricGauge(ch, "latency_spike_milliseconds", float64(spikeDuration), eventName)
+				e.registerConstMetricGauge(ch, "latency_spike_duration_seconds", spikeDurationSeconds, eventName)
 			}
 		}
 	}

--- a/exporter.go
+++ b/exporter.go
@@ -310,7 +310,7 @@ func NewRedisExporter(redisURI string, opts ExporterOptions) (*Exporter, error) 
 		"key_value":                            {txt: `The value of "key"`, lbls: []string{"db", "key"}},
 		"last_slow_execution_duration_seconds": {txt: `The amount of time needed for last slow execution, in seconds`},
 		"latency_spike_last":                   {txt: `When the latency spike last occurred`, lbls: []string{"event_name"}},
-		"latency_spike_timestamp_seconds":      {txt: `Length of the last latency spike in seconds`, lbls: []string{"event_name"}},
+		"latency_spike_milliseconds":           {txt: `Length of the last latency spike in milliseconds`, lbls: []string{"event_name"}},
 		"master_link_up":                       {txt: "Master link status on Redis slave"},
 		"script_values":                        {txt: "Values returned by the collect script", lbls: []string{"key"}},
 		"slave_info":                           {txt: "Information about the Redis slave", lbls: []string{"master_host", "master_port", "read_only"}},
@@ -886,9 +886,8 @@ func (e *Exporter) extractLatencyMetrics(ch chan<- prometheus.Metric, c redis.Co
 			latencyResult := tempVal[0].([]interface{})
 			var spikeLast, spikeDuration, max int64
 			if _, err := redis.Scan(latencyResult, &eventName, &spikeLast, &spikeDuration, &max); err == nil {
-				spikeDuration = spikeDuration / 1e6
 				e.registerConstMetricGauge(ch, "latency_spike_last", float64(spikeLast), eventName)
-				e.registerConstMetricGauge(ch, "latency_spike_timestamp_seconds", float64(spikeDuration), eventName)
+				e.registerConstMetricGauge(ch, "latency_spike_milliseconds", float64(spikeDuration), eventName)
 			}
 		}
 	}

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -187,7 +187,7 @@ func TestLatencySpike(t *testing.T) {
 			// Because we're dealing with latency, there might be a slight delay
 			// even after sleeping for a specific amount of time so checking
 			// to see if we're between +-5 of our expected value
-			if val > float64(TimeToSleep)-5 && val < float64(TimeToSleep)+5 {
+			if val > float64(TimeToSleep)+5 || val < float64(TimeToSleep)-5 {
 				t.Errorf("values not matching, %f != %f", float64(TimeToSleep), val)
 			}
 		}

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -11,6 +11,7 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
+	"math"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -187,7 +188,7 @@ func TestLatencySpike(t *testing.T) {
 			// Because we're dealing with latency, there might be a slight delay
 			// even after sleeping for a specific amount of time so checking
 			// to see if we're between +-5 of our expected value
-			if val > float64(TimeToSleep)+5 || val < float64(TimeToSleep)-5 {
+			if math.Abs(float64(TimeToSleep) - val) > 5 {
 				t.Errorf("values not matching, %f != %f", float64(TimeToSleep), val)
 			}
 		}

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -188,7 +188,7 @@ func TestLatencySpike(t *testing.T) {
 			// Because we're dealing with latency, there might be a slight delay
 			// even after sleeping for a specific amount of time so checking
 			// to see if we're between +-5 of our expected value
-			if math.Abs(float64(TimeToSleep) - val) > 5 {
+			if math.Abs(float64(TimeToSleep)-val) > 5 {
 				t.Errorf("values not matching, %f != %f", float64(TimeToSleep), val)
 			}
 		}


### PR DESCRIPTION
In 0.x versions, the duration of the most recent latency spike was expressed using the `latency_spike_milliseconds` metric. This metric name actually made a lot of sense when compared with the [Redis docs for these values](https://redis.io/topics/latency-monitor#latency-latest). In 1.x versions, this metric seems to have been replaced with a `latency_spike_timestamp_seconds` metric along with a transformation that is applied to the value to try to match the new unit.

The name of the new metric suggests to me that it might have been intended to be a replacement for `latency_spike_last` or something, but that it replaced the wrong metric. At any rate, this change adds the old metric (`latency_spike_milliseconds`) back in, and corrects the transformation for the existing metric to not truncate and to express the value in the advertised unit.

Would like to get your feedback on this, so let me know what you think. I'm down to make more changes if you have any further suggestions. Thanks for your work!