### PR TITLE
Added alpine docker image tag

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -144,7 +144,7 @@ steps:
   - name: release-docker-image-alpine-amd64
     image: plugins/docker
     settings:
-      tags: "${DRONE_TAG}-alpine"
+      tags: "alpine,${DRONE_TAG}-alpine"
       dockerfile: ./docker/Dockerfile.amd64
       repo: oliver006/redis_exporter
       target: alpine


### PR DESCRIPTION
To get the latest scratch image we can use the `latest` tag but we can't specify the latest Alpine based image without specifying an exact version for example `v1.2.1-alpine`, so I have added the `alpine` tag which serves the same purpose of `latest` but for Alpine based images.