### PR TITLE
Fix command calls/sec grafana dashboard panel hover tooltip

### DIFF
--- a/contrib/grafana_prometheus_redis_dashboard.json
+++ b/contrib/grafana_prometheus_redis_dashboard.json
@@ -1114,7 +1114,7 @@
         "msResolution": true,
         "shared": true,
         "sort": 0,
-        "value_type": "cumulative"
+        "value_type": "individual"
       },
       "type": "graph",
       "xaxis": {


### PR DESCRIPTION
The hover tooltip is wrong as it sums up every value which it shouldn't be doing if we want to see a real command call counts. The tooltip type should be set to "individual" to fix the value stacking/summing up issue.

Wrong tooltip:
![image](https://user-images.githubusercontent.com/416302/67585468-c6cdf280-f779-11e9-9eff-a7cb14913a63.png)

Correct tooltip:
![image](https://user-images.githubusercontent.com/416302/67585357-938b6380-f779-11e9-9148-53e7e9a8e587.png)