### PR TITLE
set-client-name flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ export-client-list     | REDIS_EXPORTER_EXPORT_CLIENT_LIST    | Whether to scrap
 skip-tls-verification  | REDIS_EXPORTER_SKIP_TLS_VERIFICATION | Whether to to skip TLS verification
 tls-client-key-file    | REDIS_EXPORTER_TLS_CLIENT_KEY_FILE   | Name of the client key file (including full path) if the server requires TLS client authentication
 tls-client-cert-file   | REDIS_EXPORTER_TLS_CLIENT_CERT_FILE  | Name the client cert file (including full path) if the server requires TLS client authentication
+set-client-name        | REDIS_EXPORTER_SET_CLIENT_NAME       | Whether to set client name to redis_exporter, defaults to true.
 
 Redis instance addresses can be tcp addresses: `redis://localhost:6379`, `redis.example.com:6379` or e.g. unix sockets: `unix:///tmp/redis.sock`.\
 SSL is supported by using the `rediss://` schema, for example: `rediss://azure-ssl-enabled-host.redis.cache.windows.net:6380` (note that the port is required when connecting to a non-standard 6379 port, e.g. with Azure Redis instances).\

--- a/exporter.go
+++ b/exporter.go
@@ -59,6 +59,7 @@ type ExporterOptions struct {
 	ClientCertificates  []tls.Certificate
 	InclSystemMetrics   bool
 	SkipTLSVerification bool
+	SetClientName       bool
 	IsTile38            bool
 	ExportClientList    bool
 	ConnectionTimeouts  time.Duration
@@ -1138,8 +1139,10 @@ func (e *Exporter) scrapeRedisHost(ch chan<- prometheus.Metric) error {
 
 	log.Debugf("connected to: %s", e.redisAddr)
 
-	if _, err := doRedisCmd(c, "CLIENT", "SETNAME", "redis_exporter"); err != nil {
-		log.Errorf("Couldn't set client name, err: %s", err)
+	if e.options.SetClientName {
+		if _, err := doRedisCmd(c, "CLIENT", "SETNAME", "redis_exporter"); err != nil {
+			log.Errorf("Couldn't set client name, err: %s", err)
+		}
 	}
 
 	dbCount := 0

--- a/main.go
+++ b/main.go
@@ -28,11 +28,14 @@ func getEnv(key string, defaultVal string) string {
 	return defaultVal
 }
 
-func getEnvBool(key string) (res bool) {
+func getEnvBool(key string, defaultVal bool) bool {
 	if envVal, ok := os.LookupEnv(key); ok {
-		res, _ = strconv.ParseBool(envVal)
+		envBool, err := strconv.ParseBool(envVal)
+		if err == nil {
+			return envBool
+		}
 	}
-	return res
+	return defaultVal
 }
 
 func main() {
@@ -50,13 +53,14 @@ func main() {
 		connectionTimeout   = flag.String("connection-timeout", getEnv("REDIS_EXPORTER_CONNECTION_TIMEOUT", "15s"), "Timeout for connection to Redis instance")
 		tlsClientKeyFile    = flag.String("tls-client-key-file", getEnv("REDIS_EXPORTER_TLS_CLIENT_KEY_FILE", ""), "Name of the client key file (including full path) if the server requires TLS client authentication")
 		tlsClientCertFile   = flag.String("tls-client-cert-file", getEnv("REDIS_EXPORTER_TLS_CLIENT_CERT_FILE", ""), "Name of the client certificate file (including full path) if the server requires TLS client authentication")
-		isDebug             = flag.Bool("debug", getEnvBool("REDIS_EXPORTER_DEBUG"), "Output verbose debug information")
-		isTile38            = flag.Bool("is-tile38", getEnvBool("REDIS_EXPORTER_IS_TILE38"), "Whether to scrape Tile38 specific metrics")
-		exportClientList    = flag.Bool("export-client-list", getEnvBool("REDIS_EXPORTER_EXPORT_CLIENT_LIST"), "Whether to scrape Client List specific metrics")
+		isDebug             = flag.Bool("debug", getEnvBool("REDIS_EXPORTER_DEBUG", false), "Output verbose debug information")
+		setClientName       = flag.Bool("set-client-name", getEnvBool("REDIS_EXPORTER_SET_CLIENT_NAME", true), "Whether to set client name to redis_exporter")
+		isTile38            = flag.Bool("is-tile38", getEnvBool("REDIS_EXPORTER_IS_TILE38", false), "Whether to scrape Tile38 specific metrics")
+		exportClientList    = flag.Bool("export-client-list", getEnvBool("REDIS_EXPORTER_EXPORT_CLIENT_LIST", false), "Whether to scrape Client List specific metrics")
 		showVersion         = flag.Bool("version", false, "Show version information and exit")
-		redisMetricsOnly    = flag.Bool("redis-only-metrics", getEnvBool("REDIS_EXPORTER_REDIS_ONLY_METRICS"), "Whether to also export go runtime metrics")
-		inclSystemMetrics   = flag.Bool("include-system-metrics", getEnvBool("REDIS_EXPORTER_INCL_SYSTEM_METRICS"), "Whether to include system metrics like e.g. redis_total_system_memory_bytes")
-		skipTLSVerification = flag.Bool("skip-tls-verification", getEnvBool("REDIS_EXPORTER_SKIP_TLS_VERIFICATION"), "Whether to to skip TLS verification")
+		redisMetricsOnly    = flag.Bool("redis-only-metrics", getEnvBool("REDIS_EXPORTER_REDIS_ONLY_METRICS", false), "Whether to also export go runtime metrics")
+		inclSystemMetrics   = flag.Bool("include-system-metrics", getEnvBool("REDIS_EXPORTER_INCL_SYSTEM_METRICS", false), "Whether to include system metrics like e.g. redis_total_system_memory_bytes")
+		skipTLSVerification = flag.Bool("skip-tls-verification", getEnvBool("REDIS_EXPORTER_SKIP_TLS_VERIFICATION", false), "Whether to to skip TLS verification")
 	)
 	flag.Parse()
 
@@ -122,6 +126,7 @@ func main() {
 			CheckSingleKeys:     *checkSingleKeys,
 			LuaScript:           ls,
 			InclSystemMetrics:   *inclSystemMetrics,
+			SetClientName:       *setClientName,
 			IsTile38:            *isTile38,
 			ExportClientList:    *exportClientList,
 			SkipTLSVerification: *skipTLSVerification,


### PR DESCRIPTION
Google Cloud Memorystore for Redis blocks use of the CLIENT command.

https://cloud.google.com/memorystore/docs/redis/product-constraints#blocked_redis_commands

This causes an error to be logged with each scrape.

This flag provides the option to disable the `CLIENT SETNAME redis_exporter`

🙂 