### PR TITLE
[Dashboard] Refactor to allow viewing of multiples Redises (Redi?) simultaneously.

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,10 @@ Example [Grafana](http://grafana.org/) screenshots:
 
 Grafana dashboard is available on [grafana.com](https://grafana.com/dashboards/763) and/or [github.com](contrib/grafana_prometheus_redis_dashboard.json).
 
+### Viewing multiple Redis simultaneously
+
+If running [Redis Sentinel](https://redis.io/topics/sentinel), it may be desirable to view the metrics of the various cluster members simultaneously. For this reason the dashboard's drop down is of the multi-value type, allowing for the selection of multiple Redis. Please note that there is a  caveat; the single stat panels up top namely `uptime`, `total memory use` and `clients` do not function upon viewing multiple Redis.
+
 ## Communal effort
 
 Open an issue or PR if you have more suggestions, questions or ideas about what to add.

--- a/contrib/grafana_prometheus_redis_dashboard.json
+++ b/contrib/grafana_prometheus_redis_dashboard.json
@@ -53,7 +53,7 @@
   "gnetId": 763,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1583760176275,
+  "iteration": 1583850456553,
   "links": [],
   "panels": [
     {
@@ -79,7 +79,7 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 2,
+        "w": 3,
         "x": 0,
         "y": 0
       },
@@ -133,7 +133,7 @@
         }
       ],
       "thresholds": "",
-      "title": "Uptime",
+      "title": "Max Uptime",
       "type": "singlestat",
       "valueFontSize": "70%",
       "valueMaps": [
@@ -169,7 +169,7 @@
       "gridPos": {
         "h": 7,
         "w": 2,
-        "x": 2,
+        "x": 3,
         "y": 0
       },
       "hideTimeOverride": true,
@@ -259,8 +259,8 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 4,
-        "x": 4,
+        "w": 3,
+        "x": 5,
         "y": 0
       },
       "hideTimeOverride": true,
@@ -303,7 +303,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "max(100 * (redis_memory_used_bytes{instance=~\"$instance\"}  / redis_memory_max_bytes{instance=~\"$instance\"}))",
+          "expr": "sum(100 * (redis_memory_used_bytes{instance=~\"$instance\"}  / redis_memory_max_bytes{instance=~\"$instance\"}))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -350,6 +350,8 @@
       "legend": {
         "avg": false,
         "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
         "max": false,
         "min": false,
         "show": false,
@@ -373,7 +375,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(10, sum(irate(redis_commands_total{instance=~\"$instance\"} [1m])) by (cmd))",
+          "expr": "sum(rate(redis_commands_total{instance=~\"$instance\"} [1m])) by (cmd)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -775,12 +777,14 @@
       "id": 5,
       "isNew": true,
       "legend": {
-        "alignAsTable": true,
+        "alignAsTable": false,
         "avg": false,
         "current": true,
+        "hideEmpty": false,
+        "hideZero": true,
         "max": false,
         "min": false,
-        "rightSide": true,
+        "rightSide": false,
         "show": true,
         "total": false,
         "values": true
@@ -802,7 +806,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (redis_db_keys{instance=~\"$instance\"}) by (db, instance) != 0",
+          "expr": "sum (redis_db_keys{instance=~\"$instance\"}) by (db, instance)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1185,7 +1189,7 @@
       "datasource": "${DS_PROMETHEUS}",
       "editable": true,
       "error": false,
-      "fill": 1,
+      "fill": 2,
       "fillGradient": 0,
       "grid": {},
       "gridPos": {
@@ -1200,6 +1204,8 @@
       "legend": {
         "avg": false,
         "current": false,
+        "hideEmpty": false,
+        "hideZero": true,
         "max": false,
         "min": false,
         "show": true,
@@ -1223,7 +1229,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(10,\n  sum(irate(redis_commands_duration_seconds_total{instance =~ \"$instance\"}[1m])) by (cmd)\n    /\n  sum(irate(redis_commands_total{instance =~ \"$instance\"}[1m])) by (cmd)\n)",
+          "expr": "sum(irate(redis_commands_duration_seconds_total{instance =~ \"$instance\"}[1m])) by (cmd)\n  /\nsum(irate(redis_commands_total{instance =~ \"$instance\"}[1m])) by (cmd)\n",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1298,6 +1304,8 @@
       "legend": {
         "avg": false,
         "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
         "max": false,
         "min": false,
         "show": true,
@@ -1321,7 +1329,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(10, sum(irate(redis_commands_duration_seconds_total{instance=~\"$instance\"}[1m])) by (cmd))",
+          "expr": "sum(irate(redis_commands_duration_seconds_total{instance=~\"$instance\"}[1m])) by (cmd) != 0",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,

--- a/contrib/grafana_prometheus_redis_dashboard.json
+++ b/contrib/grafana_prometheus_redis_dashboard.json
@@ -53,7 +53,7 @@
   "gnetId": 763,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1582221373482,
+  "iteration": 1583760176275,
   "links": [],
   "panels": [
     {
@@ -212,7 +212,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "redis_connected_clients{instance=~\"$instance\"}",
+          "expr": "sum(redis_connected_clients{instance=~\"$instance\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -303,7 +303,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "100 * (redis_memory_used_bytes{instance=~\"$instance\"}  / redis_memory_max_bytes{instance=~\"$instance\"})",
+          "expr": "max(100 * (redis_memory_used_bytes{instance=~\"$instance\"}  / redis_memory_max_bytes{instance=~\"$instance\"}))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -352,7 +352,7 @@
         "current": false,
         "max": false,
         "min": false,
-        "show": true,
+        "show": false,
         "total": false,
         "values": false
       },
@@ -373,7 +373,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(topk(10, irate(redis_commands_total{instance=~\"$instance\"} [1m]))) by (cmd)",
+          "expr": "topk(10, sum(irate(redis_commands_total{instance=~\"$instance\"} [1m])) by (cmd))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -477,7 +477,7 @@
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "hits",
+          "legendFormat": "hits, {{ instance }}",
           "metric": "",
           "refId": "A",
           "step": 240,
@@ -489,7 +489,7 @@
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "misses",
+          "legendFormat": "misses, {{ instance }}",
           "metric": "",
           "refId": "B",
           "step": 240,
@@ -588,21 +588,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "redis_memory_used_bytes{instance=~\"$instance\"} ",
+          "expr": "redis_memory_used_bytes{instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "used",
+          "legendFormat": "used, {{ instance }}",
           "metric": "",
           "refId": "A",
           "step": 240,
           "target": ""
         },
         {
-          "expr": "redis_memory_max_bytes{instance=~\"$instance\"} ",
+          "expr": "redis_memory_max_bytes{instance=~\"$instance\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
-          "legendFormat": "max",
+          "legendFormat": "max, {{ instance }}",
           "refId": "B",
           "step": 240
         }
@@ -695,7 +695,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(redis_net_input_bytes_total{instance=~\"$instance\"}[5m])",
+          "expr": "sum(rate(redis_net_input_bytes_total{instance=~\"$instance\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ input }}",
@@ -703,7 +703,7 @@
           "step": 240
         },
         {
-          "expr": "rate(redis_net_output_bytes_total{instance=~\"$instance\"}[5m])",
+          "expr": "sum(rate(redis_net_output_bytes_total{instance=~\"$instance\"}[5m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -802,11 +802,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (redis_db_keys{instance=~\"$instance\"}) by (db)",
+          "expr": "sum (redis_db_keys{instance=~\"$instance\"}) by (db, instance) != 0",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "{{ db }} ",
+          "legendFormat": "{{ db }}, {{ instance }}",
           "refId": "A",
           "step": 240,
           "target": ""
@@ -900,21 +900,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (redis_db_keys{instance=~\"$instance\"}) - sum (redis_db_keys_expiring{instance=~\"$instance\"}) ",
+          "expr": "sum (redis_db_keys{instance=~\"$instance\"}) by (instance) - sum (redis_db_keys_expiring{instance=~\"$instance\"}) by (instance)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "not expiring",
+          "legendFormat": "not expiring, {{ instance }}",
           "refId": "A",
           "step": 240,
           "target": ""
         },
         {
-          "expr": "sum (redis_db_keys_expiring{instance=~\"$instance\"})",
+          "expr": "sum (redis_db_keys_expiring{instance=~\"$instance\"}) by (instance)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "expiring",
+          "legendFormat": "expiring, {{ instance }}",
           "metric": "",
           "refId": "B",
           "step": 240
@@ -1022,7 +1022,7 @@
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "expired",
+          "legendFormat": "expired, {{ instance }}",
           "metric": "",
           "refId": "A",
           "step": 240,
@@ -1033,7 +1033,7 @@
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "evicted",
+          "legendFormat": "evicted, {{ instance }}",
           "refId": "B",
           "step": 240
         }
@@ -1122,14 +1122,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "redis_connected_clients{instance=\"$instance\"}",
+          "expr": "sum(redis_connected_clients{instance=~\"$instance\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "connected",
           "refId": "A"
         },
         {
-          "expr": "redis_blocked_clients{instance=\"$instance\"}",
+          "expr": "sum(redis_blocked_clients{instance=~\"$instance\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "blocked",
@@ -1223,7 +1223,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(10,\n  sum(irate(redis_commands_duration_seconds_total{instance = \"$instance\"}[1m])) by (cmd)\n    /\n  sum(irate(redis_commands_total{instance = \"$instance\"}[1m])) by (cmd)\n)",
+          "expr": "topk(10,\n  sum(irate(redis_commands_duration_seconds_total{instance =~ \"$instance\"}[1m])) by (cmd)\n    /\n  sum(irate(redis_commands_total{instance =~ \"$instance\"}[1m])) by (cmd)\n)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1391,7 +1391,7 @@
         "hide": 0,
         "includeAll": false,
         "label": null,
-        "multi": false,
+        "multi": true,
         "name": "instance",
         "options": [],
         "query": "label_values(redis_up, instance)",
@@ -1438,5 +1438,5 @@
   },
   "timezone": "browser",
   "title": "Redis Dashboard for Prometheus Redis Exporter 1.x",
-  "version": 13
+  "version": 14
 }


### PR DESCRIPTION
To view a redis cluster as a whole, the drop down is converted to a multi value. 


Hi @oliver006, this is a first pass, let me know what you think and if you are still on board with this change? 

As per above, opted for metrics by instance for the most part, but cannot quite get Connected/Blocked Clients nor Average Time Spent by Command panels to display ANYTHING. Thoughts?

fixes #352

Oh I also went and hid the legend for Total Commands up top as per our other convo.