### PR TITLE
fix commands stats in redis 5

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -690,7 +690,7 @@ func (e *Exporter) handleMetricsCommandStats(ch chan<- prometheus.Metric, fieldK
 	}
 
 	splitValue := strings.Split(fieldValue, ",")
-	if len(splitValue) != 3 {
+	if len(splitValue) < 3 {
 		return
 	}
 


### PR DESCRIPTION
In redis 5.0, the commands stats info format is like this:

```
cmdstat_pexpire:calls=1120,usec=1438,usec_per_call=1.28,rt=0,max_rt=0,request_len=0,response_len=0,receives=0,qps=0
cmdstat_rpush:calls=715,usec=3577,usec_per_call=5.00,rt=0,max_rt=0,request_len=0,response_len=0,receives=715,qps=0
cmdstat_pexpireat:calls=107,usec=234,usec_per_call=2.19,rt=0,max_rt=0,request_len=0,response_len=0,receives=107,qps=0
cmdstat_select:calls=1685,usec=1245,usec_per_call=0.74,rt=0,max_rt=0,request_len=0,response_len=0,receives=1689,qps=0
cmdstat_lrange:calls=919,usec=1993,usec_per_call=2.17,rt=0,max_rt=0,request_len=0,response_len=0,receives=919,qps=0
cmdstat_info:calls=4057140,usec=166840049,usec_per_call=41.12,rt=40,max_rt=57,request_len=4,response_len=3178,receives=4057152,qps=14
...
```
There need a small change to ensure that command statistics is work.