### PR TITLE
Preserve rid of username/password on scrape target

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -88,8 +88,6 @@ func (e *Exporter) scrapeHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// get rid of username/password info in "target" so users don't send them in plain text via http
-	u.User = nil
 	target = u.String()
 
 	opts := e.options


### PR DESCRIPTION
The comment on the code explains that the rid is removed to avoid exposing username and password on HTTP plain text connection, but sometimes it is the only way to connect.

Having in mind of covering the majority of the use cases this PR fixes #364 