### PR TITLE
Pass RootCAs to dialTLSConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ export-client-list     | REDIS_EXPORTER_EXPORT_CLIENT_LIST    | Whether to scrap
 skip-tls-verification  | REDIS_EXPORTER_SKIP_TLS_VERIFICATION | Whether to to skip TLS verification
 tls-client-key-file    | REDIS_EXPORTER_TLS_CLIENT_KEY_FILE   | Name of the client key file (including full path) if the server requires TLS client authentication
 tls-client-cert-file   | REDIS_EXPORTER_TLS_CLIENT_CERT_FILE  | Name the client cert file (including full path) if the server requires TLS client authentication
+tls-ca-cert-file       | REDIS_EXPORTER_TLS_CA_CERT_FILE      | Name of the CA certificate file (including full path) if the server requires TLS client authentication
 set-client-name        | REDIS_EXPORTER_SET_CLIENT_NAME       | Whether to set client name to redis_exporter, defaults to true.
 
 Redis instance addresses can be tcp addresses: `redis://localhost:6379`, `redis.example.com:6379` or e.g. unix sockets: `unix:///tmp/redis.sock`.\

--- a/exporter.go
+++ b/exporter.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"net/http"
@@ -58,6 +59,7 @@ type Options struct {
 	CheckKeys           string
 	LuaScript           []byte
 	ClientCertificates  []tls.Certificate
+	CaCertificates      *x509.CertPool
 	InclSystemMetrics   bool
 	SkipTLSVerification bool
 	SetClientName       bool
@@ -1187,6 +1189,7 @@ func (e *Exporter) connectToRedis() (redis.Conn, error) {
 		redis.DialTLSConfig(&tls.Config{
 			InsecureSkipVerify: e.options.SkipTLSVerification,
 			Certificates:       e.options.ClientCertificates,
+			RootCAs:            e.options.CaCertificates,
 		}),
 	}
 

--- a/main.go
+++ b/main.go
@@ -116,7 +116,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("Couldn't load TLS Ca certificate, err: %s", err)
 		}
-		tlsCaCertificates := x509.NewCertPool()
+		tlsCaCertificates = x509.NewCertPool()
 		tlsCaCertificates.AppendCertsFromPEM(caCert)
 	}
 


### PR DESCRIPTION
Fixes #387

Added paramater REDIS_EXPORTER_TLS_CA_CERT_FILE --> Name of the CA certificate file (including full path) if the server requires TLS client authentication