### PR TITLE
Add role label to keys and cmd stats

### DIFF
--- a/exporter_test.go
+++ b/exporter_test.go
@@ -1065,8 +1065,8 @@ func TestHTTPScrapeMetricsEndpoints(t *testing.T) {
 				`test_key_size{db="db11",key="` + keys[0] + `"} 7`,
 				`test_key_value{db="db11",key="` + keys[0] + `"} 1234.56`,
 
-				`test_db_keys{db="db11"} `,
-				`test_db_keys_expiring{db="db11"} `,
+				`test_db_keys{db="db11",role="master"} `,
+				`test_db_keys_expiring{db="db11",role="master"} `,
 			}
 
 			body := downloadURL(t, u)


### PR DESCRIPTION
This adds a `role` label to the metrics in the command and keyspace categories. This allows us to monitor our Redis Clusters with "Total Commands/Sec By Role" and "Total Keys By Role" charts which give insight on how much unique commands we actually process and unique data we store.

The result looks like this:
```
# HELP redis_db_keys Total number of keys by DB
# TYPE redis_db_keys gauge
redis_db_keys{db="db0",role="master"} 0
redis_db_keys{db="db1",role="master"} 0
redis_db_keys{db="db10",role="master"} 0
redis_db_keys{db="db11",role="master"} 0
redis_db_keys{db="db12",role="master"} 0
redis_db_keys{db="db13",role="master"} 0
redis_db_keys{db="db14",role="master"} 0
redis_db_keys{db="db15",role="master"} 0
redis_db_keys{db="db2",role="master"} 0
redis_db_keys{db="db3",role="master"} 0
redis_db_keys{db="db4",role="master"} 0
redis_db_keys{db="db5",role="master"} 0
redis_db_keys{db="db6",role="master"} 0
redis_db_keys{db="db7",role="master"} 0
redis_db_keys{db="db8",role="master"} 0
redis_db_keys{db="db9",role="master"} 0
# HELP redis_db_keys_expiring Total number of expiring keys by DB
# TYPE redis_db_keys_expiring gauge
redis_db_keys_expiring{db="db0",role="master"} 0
redis_db_keys_expiring{db="db1",role="master"} 0
redis_db_keys_expiring{db="db10",role="master"} 0
redis_db_keys_expiring{db="db11",role="master"} 0
redis_db_keys_expiring{db="db12",role="master"} 0
redis_db_keys_expiring{db="db13",role="master"} 0
redis_db_keys_expiring{db="db14",role="master"} 0
redis_db_keys_expiring{db="db15",role="master"} 0
redis_db_keys_expiring{db="db2",role="master"} 0
redis_db_keys_expiring{db="db3",role="master"} 0
redis_db_keys_expiring{db="db4",role="master"} 0
redis_db_keys_expiring{db="db5",role="master"} 0
redis_db_keys_expiring{db="db6",role="master"} 0
redis_db_keys_expiring{db="db7",role="master"} 0
redis_db_keys_expiring{db="db8",role="master"} 0
redis_db_keys_expiring{db="db9",role="master"} 0
```

A note on the implementation:  We currently depend on the implementation detail that the Redis `INFO` command returns the `replication` section before the `keyspace` and `commands` sections. Stock Redis will always do this but custom implementations might not. We could also split the logic to do two passes over the output, looking for instance information in the first pass and keyspace/commands in the second but that'd make the change more complex. Let me know what you think.