### PR TITLE
Issue #405 | Add sentinel info metrics

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -65,6 +65,13 @@ services:
     ports:
       - 9851
 
+  - name: redis-sentinel
+    image: docker.io/bitnami/redis-sentinel:6.0-debian-10
+    environment:
+      REDIS_MASTER_HOST: redis6
+    ports:
+      - 26379
+
 
 steps:
   - name: build-binaries

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ test:
 	TEST_REDIS_CLUSTER_MASTER_URI="redis://redis-cluster:7000" \
 	TEST_REDIS_CLUSTER_SLAVE_URI="redis://redis-cluster:7005" \
 	TEST_TILE38_URI="redis://tile38:9851" \
+	TEST_REDIS_SENTINEL_URI="redis://redis-sentinel:26379" \
 	go test -v -covermode=atomic -cover -race -coverprofile=coverage.txt ./...
 
 

--- a/contrib/docker-compose-for-tests.yml
+++ b/contrib/docker-compose-for-tests.yml
@@ -47,6 +47,13 @@ services:
     image: grokzen/redis-cluster
     ports: [7000, 7001, 7002, 7003, 7004, 7005]
 
+  redis-sentinel:
+    image: docker.io/bitnami/redis-sentinel:6.0-debian-10
+    environment:
+      -  REDIS_MASTER_HOST=redis6
+    ports:
+      - 26379
+
   tile38:
     image: tile38/tile38:latest
     ports:


### PR DESCRIPTION
Implements #405 
The division into three metrics (`sentinel_master_up`, `sentinel_master_sdown`, `sentinel_master_odown`) is deliberately done so that users have the opportunity to get both the master status _(up or not)_ and a specific state in case of an error: `sdown` or `odown`.

Info and descriptions from:
- https://redis.io/topics/sentinel
- https://github.com/redis/redis/blob/6.0/src/sentinel.c#L3406