### PR TITLE
fix k8s deployment example with proper api version and selector added

### DIFF
--- a/contrib/k8s-redis-and-exporter-deployment.yaml
+++ b/contrib/k8s-redis-and-exporter-deployment.yaml
@@ -4,13 +4,16 @@ kind: Namespace
 metadata:
   name: redis
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: redis
   name: redis
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: redis
   template:
     metadata:
       annotations:


### PR DESCRIPTION
The example now should be simple apply, no need for local fixes.