### PR TITLE
Exporter as lib

### DIFF
--- a/lib/exporter/exporter.go
+++ b/lib/exporter/exporter.go
@@ -1,4 +1,4 @@
-package main
+package exporter
 
 import (
 	"crypto/tls"
@@ -19,6 +19,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 )
+
+type BuildInfo struct {
+	Version   string
+	CommitSha string
+	Date      string
+}
 
 type dbKeyPair struct {
 	db, key string
@@ -71,6 +77,8 @@ type Exporter struct {
 	metricMapGauges   map[string]string
 
 	mux *http.ServeMux
+
+	buildInfo BuildInfo
 }
 
 type Options struct {
@@ -82,7 +90,6 @@ type Options struct {
 	CheckStreams        string
 	CheckSingleStreams  string
 	CheckKeys           string
-	CountKeys           string
 	LuaScript           []byte
 	ClientCertificates  []tls.Certificate
 	CaCertificates      *x509.CertPool
@@ -139,14 +146,10 @@ func (e *Exporter) scrapeHandler(w http.ResponseWriter, r *http.Request) {
 		opts.CheckSingleStreams = css
 	}
 
-	if cntk := r.URL.Query().Get("count-keys"); cntk != "" {
-		opts.CountKeys = cntk
-	}
-
 	registry := prometheus.NewRegistry()
 	opts.Registry = registry
 
-	_, err = NewRedisExporter(target, opts)
+	_, err = NewRedisExporter(target, opts, e.buildInfo)
 	if err != nil {
 		http.Error(w, "NewRedisExporter() err: err", 400)
 		e.targetScrapeRequestErrors.Inc()
@@ -191,13 +194,15 @@ func newMetricDescr(namespace string, metricName string, docString string, label
 }
 
 // NewRedisExporter returns a new exporter of Redis metrics.
-func NewRedisExporter(redisURI string, opts Options) (*Exporter, error) {
+func NewRedisExporter(redisURI string, opts Options, bi BuildInfo) (*Exporter, error) {
 	log.Debugf("NewRedisExporter options: %#v", opts)
 
 	e := &Exporter{
 		redisAddr: redisURI,
 		options:   opts,
 		namespace: opts.Namespace,
+
+		buildInfo: bi,
 
 		totalScrapes: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: opts.Namespace,
@@ -405,12 +410,6 @@ func NewRedisExporter(redisURI string, opts Options) (*Exporter, error) {
 		log.Debugf("singleStreams: %#v", singleStreams)
 	}
 
-	if countKeys, err := parseKeyArg(opts.CountKeys); err != nil {
-		return nil, fmt.Errorf("couldn't parse count-keys: %s", err)
-	} else {
-		log.Debugf("countKeys: %#v", countKeys)
-	}
-
 	if opts.InclSystemMetrics {
 		e.metricMapGauges["total_system_memory"] = "total_system_memory_bytes"
 	}
@@ -432,7 +431,6 @@ func NewRedisExporter(redisURI string, opts Options) (*Exporter, error) {
 		"instance_info":                          {txt: "Information about the Redis instance", lbls: []string{"role", "redis_version", "redis_build_id", "redis_mode", "os", "maxmemory_policy"}},
 		"key_size":                               {txt: `The length or size of "key"`, lbls: []string{"db", "key"}},
 		"key_value":                              {txt: `The value of "key"`, lbls: []string{"db", "key"}},
-		"keys_count":                             {txt: `Count of keys`, lbls: []string{"db", "key"}},
 		"last_slow_execution_duration_seconds":   {txt: `The amount of time needed for last slow execution, in seconds`},
 		"latency_spike_last":                     {txt: `When the latency spike last occurred`, lbls: []string{"event_name"}},
 		"latency_spike_duration_seconds":         {txt: `Length of the last latency spike in seconds`, lbls: []string{"event_name"}},
@@ -480,13 +478,13 @@ func NewRedisExporter(redisURI string, opts Options) (*Exporter, error) {
 		))
 
 		if !e.options.RedisMetricsOnly {
-			buildInfo := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			buildInfoCollector := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 				Namespace: opts.Namespace,
 				Name:      "exporter_build_info",
 				Help:      "redis exporter build_info",
 			}, []string{"version", "commit_sha", "build_date", "golang_version"})
-			buildInfo.WithLabelValues(BuildVersion, BuildCommitSha, BuildDate, runtime.Version()).Set(1)
-			e.options.Registry.MustRegister(buildInfo)
+			buildInfoCollector.WithLabelValues(e.buildInfo.Version, e.buildInfo.CommitSha, e.buildInfo.Date, runtime.Version()).Set(1)
+			e.options.Registry.MustRegister(buildInfoCollector)
 		}
 	}
 
@@ -496,9 +494,9 @@ func NewRedisExporter(redisURI string, opts Options) (*Exporter, error) {
 	})
 	e.mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`<html>
-<head><title>Redis Exporter ` + BuildVersion + `</title></head>
+<head><title>Redis Exporter ` + e.buildInfo.Version + `</title></head>
 <body>
-<h1>Redis Exporter ` + BuildVersion + `</h1>
+<h1>Redis Exporter ` + e.buildInfo.Version + `</h1>
 <p><a href='` + opts.MetricsPath + `'>Metrics</a></p>
 </body>
 </html>
@@ -1136,28 +1134,6 @@ func (e *Exporter) extractStreamMetrics(ch chan<- prometheus.Metric, c redis.Con
 	}
 }
 
-func (e *Exporter) extractCountKeysMetrics(ch chan<- prometheus.Metric, c redis.Conn) {
-	cntKeys, err := parseKeyArg(e.options.CountKeys)
-	if err != nil {
-		log.Errorf("Couldn't parse given count keys: %s", err)
-		return
-	}
-
-	for _, k := range cntKeys {
-		if _, err := doRedisCmd(c, "SELECT", k.db); err != nil {
-			log.Debugf("Couldn't select database '%s' when getting stream info", k.db)
-			continue
-		}
-		cnt, err := scanForKeyCount(c, k.key)
-		if err != nil {
-			log.Errorf("couldn't get key count for '%s', err: %s", k.key, err)
-			continue
-		}
-		dbLabel := "db" + k.db
-		e.registerConstMetricGauge(ch, "keys_count", float64(cnt), dbLabel, k.key)
-	}
-}
-
 func (e *Exporter) extractLuaScriptMetrics(ch chan<- prometheus.Metric, c redis.Conn) error {
 	log.Debug("Evaluating e.options.LuaScript")
 	kv, err := redis.StringMap(doRedisCmd(c, "EVAL", e.options.LuaScript, 0, 0))
@@ -1456,30 +1432,6 @@ func scanForKeys(c redis.Conn, pattern string) ([]string, error) {
 	return keys, nil
 }
 
-func scanForKeyCount(c redis.Conn, pattern string) (int, error) {
-	iter := 0
-	keys := 0
-
-	for {
-		arr, err := redis.Values(doRedisCmd(c, "SCAN", iter, "MATCH", pattern))
-		if err != nil {
-			return keys, fmt.Errorf("error retrieving '%s' keys err: %s", pattern, err)
-		}
-		if len(arr) != 2 {
-			return keys, fmt.Errorf("invalid response from SCAN for pattern: %s", pattern)
-		}
-
-		k, _ := redis.Values(arr[1], nil)
-		keys += len(k)
-
-		if iter, _ = redis.Int(arr[0], nil); iter == 0 {
-			break
-		}
-	}
-
-	return keys, nil
-}
-
 // getKeysFromPatterns does a SCAN for a key if the key contains pattern characters
 func getKeysFromPatterns(c redis.Conn, keys []dbKeyPair) (expandedKeys []dbKeyPair, err error) {
 	expandedKeys = []dbKeyPair{}
@@ -1631,8 +1583,6 @@ func (e *Exporter) scrapeRedisHost(ch chan<- prometheus.Metric) error {
 	e.extractSlowLogMetrics(ch, c)
 
 	e.extractStreamMetrics(ch, c)
-
-	e.extractCountKeysMetrics(ch, c)
 
 	if e.options.LuaScript != nil && len(e.options.LuaScript) > 0 {
 		if err := e.extractLuaScriptMetrics(ch, c); err != nil {

--- a/lib/exporter/exporter_test.go
+++ b/lib/exporter/exporter_test.go
@@ -1,4 +1,4 @@
-package main
+package exporter
 
 /*
   to run the tests with redis running on anything but localhost:6379 use
@@ -47,6 +47,12 @@ var (
 	dbNumStr     = "11"
 	altDBNumStr  = "12"
 	dbNumStrFull = fmt.Sprintf("db%s", dbNumStr)
+
+	Build = BuildInfo{
+		Version:   "0.0.1",
+		CommitSha: "2njk32j623lj",
+		Date:      "1970-01-01",
+	}
 )
 
 const (
@@ -55,7 +61,7 @@ const (
 )
 
 func getTestExporter() *Exporter {
-	e, _ := NewRedisExporter(os.Getenv("TEST_REDIS_URI"), Options{Namespace: "test", Registry: prometheus.NewRegistry()})
+	e, _ := NewRedisExporter(os.Getenv("TEST_REDIS_URI"), Options{Namespace: "test", Registry: prometheus.NewRegistry()}, Build)
 	return e
 }
 
@@ -221,7 +227,7 @@ func TestTile38(t *testing.T) {
 	}
 
 	for _, isTile38 := range []bool{true, false} {
-		e, _ := NewRedisExporter(os.Getenv("TEST_TILE38_URI"), Options{Namespace: "test", IsTile38: isTile38})
+		e, _ := NewRedisExporter(os.Getenv("TEST_TILE38_URI"), Options{Namespace: "test", IsTile38: isTile38}, Build)
 
 		chM := make(chan prometheus.Metric)
 		go func() {
@@ -445,7 +451,7 @@ func TestHostVariations(t *testing.T) {
 	host := strings.ReplaceAll(os.Getenv("TEST_REDIS_URI"), "redis://", "")
 
 	for _, prefix := range []string{"", "redis://", "tcp://", ""} {
-		e, _ := NewRedisExporter(prefix+host, Options{SkipTLSVerification: true})
+		e, _ := NewRedisExporter(prefix+host, Options{SkipTLSVerification: true}, Build)
 		c, err := e.connectToRedis()
 		if err != nil {
 			t.Errorf("connectToRedis() err: %s", err)
@@ -537,6 +543,7 @@ func TestKeyValuesAndSizes(t *testing.T) {
 	e, _ := NewRedisExporter(
 		os.Getenv("TEST_REDIS_URI"),
 		Options{Namespace: "test", CheckSingleKeys: dbNumStrFull + "=" + url.QueryEscape(keys[0])},
+		Build,
 	)
 
 	setupDBKeys(t, os.Getenv("TEST_REDIS_URI"))
@@ -813,7 +820,7 @@ func TestGetKeyInfo(t *testing.T) {
 
 func TestKeySizeList(t *testing.T) {
 	s := dbNumStrFull + "=" + listKeys[0]
-	e, _ := NewRedisExporter(os.Getenv("TEST_REDIS_URI"), Options{Namespace: "test", CheckSingleKeys: s})
+	e, _ := NewRedisExporter(os.Getenv("TEST_REDIS_URI"), Options{Namespace: "test", CheckSingleKeys: s}, Build)
 
 	setupDBKeys(t, os.Getenv("TEST_REDIS_URI"))
 	defer deleteKeysFromDB(t, os.Getenv("TEST_REDIS_URI"))
@@ -902,7 +909,7 @@ func TestLuaScript(t *testing.T) {
 }
 
 func TestKeyValueInvalidDB(t *testing.T) {
-	e, _ := NewRedisExporter(os.Getenv("TEST_REDIS_URI"), Options{Namespace: "test", CheckSingleKeys: "999=" + url.QueryEscape(keys[0])})
+	e, _ := NewRedisExporter(os.Getenv("TEST_REDIS_URI"), Options{Namespace: "test", CheckSingleKeys: "999=" + url.QueryEscape(keys[0])}, Build)
 
 	chM := make(chan prometheus.Metric)
 	go func() {
@@ -965,7 +972,7 @@ func TestIncludeSystemMemoryMetric(t *testing.T) {
 	for _, inc := range []bool{false, true} {
 		r := prometheus.NewRegistry()
 		ts := httptest.NewServer(promhttp.HandlerFor(r, promhttp.HandlerOpts{}))
-		e, _ := NewRedisExporter(os.Getenv("TEST_REDIS_URI"), Options{Namespace: "test", InclSystemMetrics: inc})
+		e, _ := NewRedisExporter(os.Getenv("TEST_REDIS_URI"), Options{Namespace: "test", InclSystemMetrics: inc}, Build)
 		r.Register(e)
 
 		body := downloadURL(t, ts.URL+"/metrics")
@@ -987,7 +994,6 @@ func TestHTTPScrapeMetricsEndpoints(t *testing.T) {
 
 	csk := dbNumStrFull + "=" + url.QueryEscape(keys[0]) // check-single-keys
 	css := dbNumStrFull + "=" + TestStreamName           // check-single-streams
-	cntk := dbNumStrFull + "=" + keys[0] + "*"           // count-keys
 
 	testRedisIPAddress := ""
 	testRedisHostname := ""
@@ -1011,18 +1017,17 @@ func TestHTTPScrapeMetricsEndpoints(t *testing.T) {
 		csk    string
 		cs     string
 		css    string
-		cntk   string
 		pwd    string
 		target string
 	}{
-		{addr: testRedisIPAddress, csk: csk, css: css, cntk: cntk},
-		{addr: testRedisHostname, csk: csk, css: css, cntk: cntk},
-		{addr: os.Getenv("TEST_REDIS_URI"), ck: csk, cs: css, cntk: cntk},
-		{addr: os.Getenv("TEST_REDIS_URI"), csk: csk, css: css, cntk: cntk},
-		{pwd: "", target: os.Getenv("TEST_REDIS_URI"), ck: csk, cs: css, cntk: cntk},
-		{pwd: "", target: os.Getenv("TEST_REDIS_URI"), csk: csk, css: css, cntk: cntk},
-		{pwd: "redis-password", target: os.Getenv("TEST_PWD_REDIS_URI"), ck: csk, cs: css, cntk: cntk},
-		{pwd: "redis-password", target: os.Getenv("TEST_PWD_REDIS_URI"), csk: csk, cs: css, cntk: cntk},
+		{addr: testRedisIPAddress, csk: csk, css: css},
+		{addr: testRedisHostname, csk: csk, css: css},
+		{addr: os.Getenv("TEST_REDIS_URI"), ck: csk, cs: css},
+		{addr: os.Getenv("TEST_REDIS_URI"), csk: csk, css: css},
+		{pwd: "", target: os.Getenv("TEST_REDIS_URI"), ck: csk, cs: css},
+		{pwd: "", target: os.Getenv("TEST_REDIS_URI"), csk: csk, css: css},
+		{pwd: "redis-password", target: os.Getenv("TEST_PWD_REDIS_URI"), ck: csk, cs: css},
+		{pwd: "redis-password", target: os.Getenv("TEST_PWD_REDIS_URI"), csk: csk, cs: css},
 	} {
 		name := fmt.Sprintf("addr:[%s]___target:[%s]___pwd:[%s]", tst.addr, tst.target, tst.pwd)
 		t.Run(name, func(t *testing.T) {
@@ -1038,10 +1043,9 @@ func TestHTTPScrapeMetricsEndpoints(t *testing.T) {
 				options.CheckKeys = tst.ck
 				options.CheckSingleStreams = tst.css
 				options.CheckStreams = tst.cs
-				options.CountKeys = tst.cntk
 			}
 
-			e, _ := NewRedisExporter(tst.addr, options)
+			e, _ := NewRedisExporter(tst.addr, options, Build)
 			ts := httptest.NewServer(e)
 
 			u := ts.URL
@@ -1053,7 +1057,6 @@ func TestHTTPScrapeMetricsEndpoints(t *testing.T) {
 				v.Add("check-keys", tst.ck)
 				v.Add("check-streams", tst.cs)
 				v.Add("check-single-streams", tst.css)
-				v.Add("count-keys", tst.cntk)
 
 				up, _ := url.Parse(u)
 				up.RawQuery = v.Encode()
@@ -1090,8 +1093,6 @@ func TestHTTPScrapeMetricsEndpoints(t *testing.T) {
 				`test_key_size{db="db11",key="` + keys[0] + `"} 7`,
 				`test_key_value{db="db11",key="` + keys[0] + `"} 1234.56`,
 
-				`test_keys_count{db="db11",key="` + keys[0] + `*"} 1`,
-
 				`test_db_keys{db="db11"} `,
 				`test_db_keys_expiring{db="db11"} `,
 				// streams
@@ -1121,7 +1122,7 @@ func TestSimultaneousRequests(t *testing.T) {
 	setupDBKeys(t, os.Getenv("TEST_REDIS_URI"))
 	defer deleteKeysFromDB(t, os.Getenv("TEST_REDIS_URI"))
 
-	e, _ := NewRedisExporter("", Options{Namespace: "test", InclSystemMetrics: false, Registry: prometheus.NewRegistry()})
+	e, _ := NewRedisExporter("", Options{Namespace: "test", InclSystemMetrics: false, Registry: prometheus.NewRegistry()}, Build)
 	ts := httptest.NewServer(e)
 	defer ts.Close()
 
@@ -1179,7 +1180,7 @@ func TestSimultaneousRequests(t *testing.T) {
 }
 
 func TestNonExistingHost(t *testing.T) {
-	e, _ := NewRedisExporter("unix:///tmp/doesnt.exist", Options{Namespace: "test"})
+	e, _ := NewRedisExporter("unix:///tmp/doesnt.exist", Options{Namespace: "test"}, Build)
 
 	chM := make(chan prometheus.Metric)
 	go func() {
@@ -1232,7 +1233,7 @@ func TestSanitizeMetricName(t *testing.T) {
 }
 
 func TestKeysReset(t *testing.T) {
-	e, _ := NewRedisExporter(os.Getenv("TEST_REDIS_URI"), Options{Namespace: "test", CheckSingleKeys: dbNumStrFull + "=" + keys[0], Registry: prometheus.NewRegistry()})
+	e, _ := NewRedisExporter(os.Getenv("TEST_REDIS_URI"), Options{Namespace: "test", CheckSingleKeys: dbNumStrFull + "=" + keys[0], Registry: prometheus.NewRegistry()}, Build)
 	ts := httptest.NewServer(e)
 	defer ts.Close()
 
@@ -1264,7 +1265,7 @@ func TestClusterMaster(t *testing.T) {
 	}
 
 	addr := os.Getenv("TEST_REDIS_CLUSTER_MASTER_URI")
-	e, _ := NewRedisExporter(addr, Options{Namespace: "test", Registry: prometheus.NewRegistry()})
+	e, _ := NewRedisExporter(addr, Options{Namespace: "test", Registry: prometheus.NewRegistry()}, Build)
 	ts := httptest.NewServer(e)
 	defer ts.Close()
 
@@ -1300,7 +1301,7 @@ func TestPasswordProtectedInstance(t *testing.T) {
 
 		uri := os.Getenv(uriEnvName)
 
-		e, _ := NewRedisExporter(uri, Options{Namespace: "test", Registry: prometheus.NewRegistry()})
+		e, _ := NewRedisExporter(uri, Options{Namespace: "test", Registry: prometheus.NewRegistry()}, Build)
 		ts := httptest.NewServer(e)
 		defer ts.Close()
 
@@ -1325,7 +1326,7 @@ func TestPasswordInvalid(t *testing.T) {
 	testPwd := "redis-password"
 	uri := strings.Replace(os.Getenv("TEST_PWD_REDIS_URI"), testPwd, "wrong-pwd", -1)
 
-	e, _ := NewRedisExporter(uri, Options{Namespace: "test", Registry: prometheus.NewRegistry()})
+	e, _ := NewRedisExporter(uri, Options{Namespace: "test", Registry: prometheus.NewRegistry()}, Build)
 	ts := httptest.NewServer(e)
 	defer ts.Close()
 
@@ -1348,7 +1349,7 @@ func TestClusterSlave(t *testing.T) {
 	}
 
 	addr := os.Getenv("TEST_REDIS_CLUSTER_SLAVE_URI")
-	e, _ := NewRedisExporter(addr, Options{Namespace: "test", Registry: prometheus.NewRegistry()})
+	e, _ := NewRedisExporter(addr, Options{Namespace: "test", Registry: prometheus.NewRegistry()}, Build)
 	ts := httptest.NewServer(e)
 	defer ts.Close()
 
@@ -1396,7 +1397,7 @@ func TestCheckKeys(t *testing.T) {
 		{"wrong=wrong=1", "", false},
 		{"", "wrong=wrong=2", false},
 	} {
-		_, err := NewRedisExporter(os.Getenv("TEST_REDIS_URI"), Options{Namespace: "test", CheckSingleKeys: tst.SingleCheckKey, CheckKeys: tst.CheckKeys})
+		_, err := NewRedisExporter(os.Getenv("TEST_REDIS_URI"), Options{Namespace: "test", CheckSingleKeys: tst.SingleCheckKey, CheckKeys: tst.CheckKeys}, Build)
 		if tst.ExpectSuccess && err != nil {
 			t.Errorf("Expected success for test: %#v, got err: %s", tst, err)
 			return
@@ -1414,7 +1415,7 @@ func TestHTTPHTMLPages(t *testing.T) {
 		t.Skipf("TEST_PWD_REDIS_URI not set - skipping")
 	}
 
-	e, _ := NewRedisExporter(os.Getenv("TEST_PWD_REDIS_URI"), Options{Namespace: "test", Registry: prometheus.NewRegistry()})
+	e, _ := NewRedisExporter(os.Getenv("TEST_PWD_REDIS_URI"), Options{Namespace: "test", Registry: prometheus.NewRegistry()}, Build)
 	ts := httptest.NewServer(e)
 	defer ts.Close()
 
@@ -1447,7 +1448,7 @@ func TestConnectionDurations(t *testing.T) {
 	for _, inclPing := range []bool{false, true} {
 		r := prometheus.NewRegistry()
 		ts := httptest.NewServer(promhttp.HandlerFor(r, promhttp.HandlerOpts{}))
-		e, _ := NewRedisExporter(os.Getenv("TEST_REDIS_URI"), Options{Namespace: "test", PingOnConnect: inclPing})
+		e, _ := NewRedisExporter(os.Getenv("TEST_REDIS_URI"), Options{Namespace: "test", PingOnConnect: inclPing}, Build)
 		r.Register(e)
 
 		body := downloadURL(t, ts.URL+"/metrics")
@@ -1748,6 +1749,7 @@ func TestExtractStreamMetrics(t *testing.T) {
 	e, _ := NewRedisExporter(
 		addr,
 		Options{Namespace: "test", CheckSingleStreams: dbNumStrFull + "=" + TestStreamName},
+		Build,
 	)
 	c, err := redis.DialURL(addr)
 	if err != nil {
@@ -1798,6 +1800,7 @@ func TestExtractInfoMetricsSentinel(t *testing.T) {
 	e, _ := NewRedisExporter(
 		addr,
 		Options{Namespace: "test"},
+		Build,
 	)
 	c, err := redis.DialURL(addr)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/oliver006/redis_exporter/lib/exporter"
 )
 
 var (
@@ -136,9 +138,9 @@ func main() {
 		registry = prometheus.DefaultRegisterer.(*prometheus.Registry)
 	}
 
-	exp, err := NewRedisExporter(
+	exp, err := exporter.NewRedisExporter(
 		*redisAddr,
-		Options{
+		exporter.Options{
 			User:                *redisUser,
 			Password:            *redisPwd,
 			Namespace:           *namespace,
@@ -160,6 +162,11 @@ func main() {
 			RedisMetricsOnly:    *redisMetricsOnly,
 			PingOnConnect:       *pingOnConnect,
 			Registry:            registry,
+		},
+		exporter.BuildInfo{
+			Version:   BuildVersion,
+			CommitSha: BuildCommitSha,
+			Date:      BuildDate,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
These changes define the exporter logic as a library, so that it can be used in in other applications.

Summary of changes:
- Move exporter to its own directory. I called it `lib/exporter`
- Avoid use of global vars `BuildVersion`, `BuildCommitSha`, `BuildDate`. I modified `NewRedisExporter` to take a `exporter.BuildInfo` struct to pass this information around. 

Outstanding:
- [ ] Capture recent count keys changes