### PR TITLE
update redis-mixin templated datasource to use templated variable

### DIFF
--- a/contrib/redis-mixin/dashboards/redis-overview.json
+++ b/contrib/redis-mixin/dashboards/redis-overview.json
@@ -1305,7 +1305,7 @@
             "redisdb-7d6b98cd98-pbkg6"
           ]
         },
-        "datasource": "prometheus",
+        "datasource": "${datasource}",
         "definition": "label_values(redis_up, instance)",
         "hide": 0,
         "includeAll": false,


### PR DESCRIPTION
This minor update fixes a bug where the datasource in a template variable was hard coded instead of using a variable. This means the variable will work when the datasource is not called `prometheus`.