### PR TITLE
Add count-keys to the command line

### DIFF
--- a/exporter_test.go
+++ b/exporter_test.go
@@ -1231,6 +1231,19 @@ func TestSanitizeMetricName(t *testing.T) {
 	}
 }
 
+func TestParseClientListString(t *testing.T) {
+	tsts := map[string][]string{
+		"id=11 addr=127.0.0.1:63508 fd=8 name= age=6321 idle=6320 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=setex":    []string{"127.0.0.1", "63508", "", "6321", "6320", "N", "0", "0", "setex"},
+		"id=14 addr=127.0.0.1:64958 fd=9 name=foo age=5 idle=0 flags=N db=1 sub=0 psub=0 multi=-1 qbuf=26 qbuf-free=32742 obl=0 oll=0 omem=0 events=r cmd=client": []string{"127.0.0.1", "64958", "foo", "5", "0", "N", "1", "0", "client"},
+	}
+
+	for k, v := range tsts {
+		if host, port, name, age, idle, flags, db, omem, cmd, ok := parseClientListString(k); host != v[0] || port != v[1] || name != v[2] || age != v[3] || idle != v[4] || flags != v[5] || db != v[6] || omem != v[7] || cmd != v[8] || !ok {
+			t.Errorf("TestParseClientListString( %s ) error. Given: %s Wanted: %s", k, []string{host, port, name, age, idle, flags, db, omem, cmd}, v)
+		}
+	}
+}
+
 func TestKeysReset(t *testing.T) {
 	e, _ := NewRedisExporter(os.Getenv("TEST_REDIS_URI"), Options{Namespace: "test", CheckSingleKeys: dbNumStrFull + "=" + keys[0], Registry: prometheus.NewRegistry()})
 	ts := httptest.NewServer(e)

--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ func main() {
 		checkSingleKeys     = flag.String("check-single-keys", getEnv("REDIS_EXPORTER_CHECK_SINGLE_KEYS", ""), "Comma separated list of single keys to export value and length/size")
 		checkStreams        = flag.String("check-streams", getEnv("REDIS_EXPORTER_CHECK_STREAMS", ""), "Comma separated list of stream-patterns to export info about streams, groups and consumers, searched for with SCAN")
 		checkSingleStreams  = flag.String("check-single-streams", getEnv("REDIS_EXPORTER_CHECK_SINGLE_STREAMS", ""), "Comma separated list of single streams to export info about streams, groups and consumers")
+		countKeys           = flag.String("count-keys", getEnv("REDIS_EXPORTER_COUNT_KEYS", ""), "Comma separated list of patterns to count, eg: 'db3=sessions:*'. Warning: The exporter runs SCAN to count the keys.")
 		scriptPath          = flag.String("script", getEnv("REDIS_EXPORTER_SCRIPT", ""), "Path to Lua Redis script for collecting extra metrics")
 		listenAddress       = flag.String("web.listen-address", getEnv("REDIS_EXPORTER_WEB_LISTEN_ADDRESS", ":9121"), "Address to listen on for web interface and telemetry.")
 		metricPath          = flag.String("web.telemetry-path", getEnv("REDIS_EXPORTER_WEB_TELEMETRY_PATH", "/metrics"), "Path under which to expose metrics.")
@@ -147,6 +148,7 @@ func main() {
 			CheckSingleKeys:     *checkSingleKeys,
 			CheckStreams:        *checkStreams,
 			CheckSingleStreams:  *checkSingleStreams,
+			CountKeys:           *countKeys,
 			LuaScript:           ls,
 			InclSystemMetrics:   *inclSystemMetrics,
 			SetClientName:       *setClientName,


### PR DESCRIPTION
Before changes:

```
$ ./redis_exporter -count-keys "db0=xpto::*" -redis-only-metrics
flag provided but not defined: -count-keys
...

$ ./redis_exporter -help 2>&1 | grep count || echo "not found"
not found
```

After changes:

```
$ ./redis_exporter -count-keys "db0=xpto::*" -redis-only-metrics
INFO[0000] Redis Metrics Exporter     build date: 2020-10-23-19:34:19    sha1:     Go: go1.15.3    GOOS: linux    GOARCH: amd64
INFO[0000] Providing metrics at :9121/metrics

$ ./redis_exporter -help 2>&1 | grep count || echo "not found"
  -count-keys string
    	Comma separated list of patterns to count, eg: 'db3=sessions:*'. Warning: The exporter runs SCAN to count the keys.
```