### PR TITLE
Fix drone docker releases

### DIFF
--- a/docker/Dockerfile.amd64
+++ b/docker/Dockerfile.amd64
@@ -4,7 +4,7 @@
 FROM golang:1.15-alpine as builder
 WORKDIR /go/src/github.com/oliver006/redis_exporter/
 
-ADD go.mod go.sum main.go exporter.go /go/src/github.com/oliver006/redis_exporter/
+ADD .  /go/src/github.com/oliver006/redis_exporter/
 
 ARG GOARCH="amd64"
 ARG SHA1="[no-sha]"

--- a/docker/Dockerfile.arm
+++ b/docker/Dockerfile.arm
@@ -4,7 +4,7 @@
 FROM golang:1.15-alpine as builder
 WORKDIR /go/src/github.com/oliver006/redis_exporter/
 
-ADD go.mod go.sum main.go exporter.go /go/src/github.com/oliver006/redis_exporter/
+ADD . /go/src/github.com/oliver006/redis_exporter/
 
 ARG GOARCH="arm"
 ARG SHA1="[no-sha]"

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -4,7 +4,7 @@
 FROM golang:1.15-alpine as builder
 WORKDIR /go/src/github.com/oliver006/redis_exporter/
 
-ADD go.mod go.sum main.go exporter.go /go/src/github.com/oliver006/redis_exporter/
+ADD .  /go/src/github.com/oliver006/redis_exporter/
 
 ARG GOARCH="arm64"
 ARG SHA1="[no-sha]"


### PR DESCRIPTION
Post merging of #435, drone docker releases are broken. Check https://cloud.drone.io/oliver006/redis_exporter/922/1/13 for reference. 
This commit fixes it.