### PR TITLE
Support for memory usage aggregation by key groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,36 +131,40 @@ Prometheus uses file watches and all changes to the json file are applied immedi
 
 ### Command line flags
 
-Name                   | Environment Variable Name            | Description
------------------------|--------------------------------------|-----------------
-redis.addr             | REDIS_ADDR                           | Address of the Redis instance, defaults to `redis://localhost:6379`.
-redis.user             | REDIS_USER                           | User name to use for authentication (Redis ACL for Redis 6.0 and newer).
-redis.password         | REDIS_PASSWORD                       | Password of the Redis instance, defaults to `""` (no password).
-check-keys             | REDIS_EXPORTER_CHECK_KEYS            | Comma separated list of key patterns to export value and length/size, eg: `db3=user_count` will export key `user_count` from db `3`. db defaults to `0` if omitted. The key patterns specified with this flag will be found using [SCAN](https://redis.io/commands/scan).  Use this option if you need glob pattern matching; `check-single-keys` is faster for non-pattern keys. Warning: using `--check-keys` to match a very large number of keys can slow down the exporter to the point where it doesn't finish scraping the redis instance.
-check-single-keys      | REDIS_EXPORTER_CHECK_SINGLE_KEYS     | Comma separated list of keys to export value and length/size, eg: `db3=user_count` will export key `user_count` from db `3`. db defaults to `0` if omitted.  The keys specified with this flag will be looked up directly without any glob pattern matching.  Use this option if you don't need glob pattern matching;  it is faster than `check-keys`.
-check-streams          | REDIS_EXPORTER_CHECK_STREAMS         | Comma separated list of stream-patterns to export info about streams, groups and consumers. Syntax is the same as `check-keys`.
-check-single-streams   | REDIS_EXPORTER_CHECK_SINGLE_STREAMS  | Comma separated list of streams to export info about streams, groups and consumers. The streams specified with this flag will be looked up directly without any glob pattern matching.  Use this option if you don't need glob pattern matching;  it is faster than `check-streams`.
-count-keys             | REDIS_EXPORTER_COUNT_KEYS            | Comma separated list of patterns to count, eg: `db3=sessions:*` will count all keys with prefix `sessions:` from db `3`. db defaults to `0` if omitted. Warning: The exporter runs SCAN to count the keys. This might not perform well on large databases.
-script                 | REDIS_EXPORTER_SCRIPT                | Path to Redis Lua script for gathering extra metrics.
-debug                  | REDIS_EXPORTER_DEBUG                 | Verbose debug output
-log-format             | REDIS_EXPORTER_LOG_FORMAT            | Log format, valid options are `txt` (default) and `json`.
-namespace              | REDIS_EXPORTER_NAMESPACE             | Namespace for the metrics, defaults to `redis`.
-connection-timeout     | REDIS_EXPORTER_CONNECTION_TIMEOUT    | Timeout for connection to Redis instance, defaults to "15s" (in Golang duration format)
-web.listen-address     | REDIS_EXPORTER_WEB_LISTEN_ADDRESS    | Address to listen on for web interface and telemetry, defaults to `0.0.0.0:9121`.
-web.telemetry-path     | REDIS_EXPORTER_WEB_TELEMETRY_PATH    | Path under which to expose metrics, defaults to `/metrics`.
-redis-only-metrics     | REDIS_EXPORTER_REDIS_ONLY_METRICS    | Whether to also export go runtime metrics, defaults to false.
-include-system-metrics | REDIS_EXPORTER_INCL_SYSTEM_METRICS   | Whether to include system metrics like `total_system_memory_bytes`, defaults to false.
-ping-on-connect        | REDIS_EXPORTER_PING_ON_CONNECT       | Whether to ping the redis instance after connecting and record the duration as a metric, defaults to false.
-is-tile38              | REDIS_EXPORTER_IS_TILE38             | Whether to scrape Tile38 specific metrics, defaults to false.
-export-client-list     | REDIS_EXPORTER_EXPORT_CLIENT_LIST    | Whether to scrape Client List specific metrics, defaults to false.
-export-client-port     | REDIS_EXPORTER_EXPORT_CLIENT_PORT    | Whether to include the client's port when exporting the client list. Warning: including the port increases the number of metrics generated and will make your Prometheus server take up more memory
-skip-tls-verification  | REDIS_EXPORTER_SKIP_TLS_VERIFICATION | Whether to to skip TLS verification
-tls-client-key-file    | REDIS_EXPORTER_TLS_CLIENT_KEY_FILE   | Name of the client key file (including full path) if the server requires TLS client authentication
-tls-client-cert-file   | REDIS_EXPORTER_TLS_CLIENT_CERT_FILE  | Name the client cert file (including full path) if the server requires TLS client authentication
-tls-server-key-file    | REDIS_EXPORTER_TLS_SERVER_KEY_FILE   | Name of the server key file (including full path) if the web interface and telemetry should use TLS
-tls-server-cert-file   | REDIS_EXPORTER_TLS_SERVER_CERT_FILE  | Name of the server certificate file (including full path) if the web interface and telemetry should use TLS
-tls-ca-cert-file       | REDIS_EXPORTER_TLS_CA_CERT_FILE      | Name of the CA certificate file (including full path) if the server requires TLS client authentication
-set-client-name        | REDIS_EXPORTER_SET_CLIENT_NAME       | Whether to set client name to redis_exporter, defaults to true.
+Name                        | Environment Variable Name                  | Description
+----------------------------|--------------------------------------------|-----------------
+redis.addr                  | REDIS_ADDR                                 | Address of the Redis instance, defaults to `redis://localhost:6379`.
+redis.user                  | REDIS_USER                                 | User name to use for authentication (Redis ACL for Redis 6.0 and newer).
+redis.password              | REDIS_PASSWORD                             | Password of the Redis instance, defaults to `""` (no password).
+check-keys                  | REDIS_EXPORTER_CHECK_KEYS                  | Comma separated list of key patterns to export value and length/size, eg: `db3=user_count` will export key `user_count` from db `3`. db defaults to `0` if omitted. The key patterns specified with this flag will be found using [SCAN](https://redis.io/commands/scan).  Use this option if you need glob pattern matching; `check-single-keys` is faster for non-pattern keys. Warning: using `--check-keys` to match a very large number of keys can slow down the exporter to the point where it doesn't finish scraping the redis instance.
+check-single-keys           | REDIS_EXPORTER_CHECK_SINGLE_KEYS           | Comma separated list of keys to export value and length/size, eg: `db3=user_count` will export key `user_count` from db `3`. db defaults to `0` if omitted.  The keys specified with this flag will be looked up directly without any glob pattern matching.  Use this option if you don't need glob pattern matching;  it is faster than `check-keys`.
+check-streams               | REDIS_EXPORTER_CHECK_STREAMS               | Comma separated list of stream-patterns to export info about streams, groups and consumers. Syntax is the same as `check-keys`.
+check-single-streams        | REDIS_EXPORTER_CHECK_SINGLE_STREAMS        | Comma separated list of streams to export info about streams, groups and consumers. The streams specified with this flag will be looked up directly without any glob pattern matching.  Use this option if you don't need glob pattern matching;  it is faster than `check-streams`.
+count-keys                  | REDIS_EXPORTER_COUNT_KEYS                  | Comma separated list of patterns to count, eg: `db3=sessions:*` will count all keys with prefix `sessions:` from db `3`. db defaults to `0` if omitted. Warning: The exporter runs SCAN to count the keys. This might not perform well on large databases.
+script                      | REDIS_EXPORTER_SCRIPT                      | Path to Redis Lua script for gathering extra metrics.
+debug                       | REDIS_EXPORTER_DEBUG                       | Verbose debug output
+log-format                  | REDIS_EXPORTER_LOG_FORMAT                  | Log format, valid options are `txt` (default) and `json`.
+namespace                   | REDIS_EXPORTER_NAMESPACE                   | Namespace for the metrics, defaults to `redis`.
+connection-timeout          | REDIS_EXPORTER_CONNECTION_TIMEOUT          | Timeout for connection to Redis instance, defaults to "15s" (in Golang duration format)
+web.listen-address          | REDIS_EXPORTER_WEB_LISTEN_ADDRESS          | Address to listen on for web interface and telemetry, defaults to `0.0.0.0:9121`.
+web.telemetry-path          | REDIS_EXPORTER_WEB_TELEMETRY_PATH          | Path under which to expose metrics, defaults to `/metrics`.
+redis-only-metrics          | REDIS_EXPORTER_REDIS_ONLY_METRICS          | Whether to also export go runtime metrics, defaults to false.
+include-system-metrics      | REDIS_EXPORTER_INCL_SYSTEM_METRICS         | Whether to include system metrics like `total_system_memory_bytes`, defaults to false.
+ping-on-connect             | REDIS_EXPORTER_PING_ON_CONNECT             | Whether to ping the redis instance after connecting and record the duration as a metric, defaults to false.
+is-tile38                   | REDIS_EXPORTER_IS_TILE38                   | Whether to scrape Tile38 specific metrics, defaults to false.
+export-client-list          | REDIS_EXPORTER_EXPORT_CLIENT_LIST          | Whether to scrape Client List specific metrics, defaults to false.
+export-client-port          | REDIS_EXPORTER_EXPORT_CLIENT_PORT          | Whether to include the client's port when exporting the client list. Warning: including the port increases the number of metrics generated and will make your Prometheus server take up more memory
+skip-tls-verification       | REDIS_EXPORTER_SKIP_TLS_VERIFICATION       | Whether to to skip TLS verification
+tls-client-key-file         | REDIS_EXPORTER_TLS_CLIENT_KEY_FILE         | Name of the client key file (including full path) if the server requires TLS client authentication
+tls-client-cert-file        | REDIS_EXPORTER_TLS_CLIENT_CERT_FILE        | Name the client cert file (including full path) if the server requires TLS client authentication
+tls-server-key-file         | REDIS_EXPORTER_TLS_SERVER_KEY_FILE         | Name of the server key file (including full path) if the web interface and telemetry should use TLS
+tls-server-cert-file        | REDIS_EXPORTER_TLS_SERVER_CERT_FILE        | Name of the server certificate file (including full path) if the web interface and telemetry should use TLS
+tls-ca-cert-file            | REDIS_EXPORTER_TLS_CA_CERT_FILE            | Name of the CA certificate file (including full path) if the server requires TLS client authentication
+set-client-name             | REDIS_EXPORTER_SET_CLIENT_NAME             | Whether to set client name to redis_exporter, defaults to true.
+check-key-groups            | REDIS_EXPORTER_CHECK_KEY_GROUPS            | Comma separated list of [LUA regexes](https://www.lua.org/pil/20.1.html) for classifying keys into groups. The regexes are applied in specified order to individual keys, and the group name is generated by concatenating all capture groups of the first regex that matches a key. A key will be tracked under the `unclassified` group if none of the specified regexes matches it.
+check-key-groups-batch-size | REDIS_EXPORTER_CHECK_KEY_GROUPS_BATCH_SIZE | Approximate number of keys to process in each execution of the server-side key group metrics aggregation LUA script. This is basically the COUNT option that will be passed into the SCAN command as part of the execution of the key group metrics aggregation LUA script to gather the batch of keys to aggregate. You can configure a smaller batch size if you want to descrease the run time of each execution of the service-side key group metrics aggregation script (thus avoiding large latency bubble in the single Redis processing thread) at the expanse of more network round-trips during key group metrics aggregation.
+max-distinct-key-groups     | MAX_DISTINCT_KEY_GROUPS                    | Maximum number of distinct key groups that can be tracked independently *per Redis database*. If exceeded, only key groups with the highest memory consumption within the limit will be tracked separately, all remaining key groups will be tracked under a single `overflow` key group.
+
 
 Redis instance addresses can be tcp addresses: `redis://localhost:6379`, `redis.example.com:6379` or e.g. unix sockets: `unix:///tmp/redis.sock`.\
 SSL is supported by using the `rediss://` schema, for example: `rediss://azure-ssl-enabled-host.redis.cache.windows.net:6380` (note that the port is required when connecting to a non-standard 6379 port, e.g. with Azure Redis instances).\
@@ -244,7 +248,6 @@ If running [Redis Sentinel](https://redis.io/topics/sentinel), it may be desirab
 ## Using the mixin
 There is a set of sample rules, alerts and dashboards available in [redis-mixin](contrib/redis-mixin/)
 
-
 ## Upgrading from 0.x to 1.x
 
 [PR #256](https://github.com/oliver006/redis_exporter/pull/256) introduced breaking changes which were released as version v1.0.0.
@@ -253,6 +256,31 @@ If you only scrape one Redis instance and use command line flags `--redis.addres
 and `--redis.password` then you're most probably not affected.
 Otherwise, please see [PR #256](https://github.com/oliver006/redis_exporter/pull/256) and [this README](https://github.com/oliver006/redis_exporter#prometheus-configuration-to-scrape-multiple-redis-hosts) for more information.
 
+## Memory Usage Aggregation by Key Groups
+
+When a single Redis instance is used for multiple purposes, it is useful to be able to see how Redis memory is consumed among the different usage scenarios. This is particularly important when a Redis instance with no eviction policy is running low on memory as we want to identify whether certain applications are misbehaving (e.g. not deleting keys that are no longer in use) or the Redis instance needs to be scaled up to handle the increased resource demand. Fortunately, most applications using Redis will employ some sort of naming conventions for keys tied to their specific purpose such as (hierarchical) namespace prefixes which can be exploited by the check-keys, check-single-keys, and count-keys parameters of redis_exporter to surface the memory usage metrics of specific scenarios. *Memory usage aggregation by key groups* takes this one step further by harnessing the flexibility of Redis LUA scripting support to classify all keys on a Redis instance into groups through a list of user-defined [LUA regular expressions](https://www.lua.org/pil/20.1.html) so memory usage metrics can be aggregated into readily identifiable groups.
+
+To enable memory usage aggregation by key groups, simply specify a non-empty comma-separated list of LUA regular expressions through the `check-key-groups` redis_exporter parameter. On each aggregation of memory metrics by key groups, redis_exporter will set up a `SCAN` cursor through all keys for each Redis database to be processed in batches via a LUA script. Each key batch is then processed by the same LUA script on a key-by-key basis as follows:
+
+  1. The `MEMORY USAGE` command is called to gather memory usage for each key
+  2. The specified LUA regexes are applied to each key in the specified order, and the group name that a given key belongs to will be derived from concatenating the capture groups of the first regex that matches the key. For example, applying the regex `^(.*)_[^_]+$` to the key `key_exp_Nick` would yield a group name of `key_exp`. If none of the specified regexes matches a key, the key will be assigned to the `unclassified` group
+
+Once a key has been classified, the memory usage and key counter for the corresponding group will be incremented in a local LUA table. This aggregated metrics table will then be returned alongside the next `SCAN` cursor position to redis_exporter when all keys in a batch have been processed, and redis_exporter can aggregate the data from all batches into a single table of grouped memory usage metrics for the Prometheus metrics scrapper.
+
+Besides making the full flexibility of LUA regex available for classifying keys into groups, the LUA script also has the benefit of reducing network traffic by executing all `MEMORY USAGE` commands on the Redis server and returning aggregated data to redis_exporter in a far more compact format than key-level data. The use of `SCAN` cursor over batches of keys processed by a server-side LUA script also helps prevent unbounded latency bubble in Redis's single processing thread, and the batch size can be tailored to specific environments via the `check-key-groups-batch-size` parameter.
+
+Scanning the entire key space of a Redis instance may sound a lttle extravagant, but it takes only a single scan to classify all keys into groups, and on a moderately sized system with ~780K keys and a rather complex list of 17 regexes, it takes an average of ~5s to perform a full aggregation of memory usage by key groups. Of course, the actual performance for specific systems will vary widely depending on the total number of keys, the number and complexity of regexes used for classification, and the configured batch size.
+
+To protect Prometheus from being overwhelmed by a large number of time series resulting from misconfigured group classification regular expression (e.g. applying the regular expression `^(.*)$` where each key will be classified into its own distinct group), a limit on the number of distinct key groups *per Redis database* can be configured via the `max-distinct-key-groups` parameter. If the `max-distinct-key-groups` limit is exceeded, only the key groups with the highest memory usage within the limit will be tracked separately, remaining key groups will be reported under a single `overflow` key group.
+
+Here is a list of additional metrics that will be exposed when memory usage aggregation by key groups is enabled:
+
+|Name                                              |Labels      |Description
+|--------------------------------------------------|------------|-----------
+|redis_key_group_count                             |db,key_group|Number of keys in a key group
+|redis_key_group_memory_usage_bytes                |db,key_group|Memory usage by key group
+|redis_number_of_distinct_key_groups               |db          |Number of distinct key groups in a Redis database when the `overflow` group is fully expanded
+|redis_last_key_groups_scrape_duration_milliseconds|            |Duration of the last memory usage aggregation by key groups in milliseconds
 
 ## Development
 

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -82,30 +82,33 @@ type Exporter struct {
 }
 
 type Options struct {
-	User                  string
-	Password              string
-	Namespace             string
-	ConfigCommandName     string
-	CheckSingleKeys       string
-	CheckStreams          string
-	CheckSingleStreams    string
-	CheckKeys             string
-	CountKeys             string
-	LuaScript             []byte
-	ClientCertificates    []tls.Certificate
-	CaCertificates        *x509.CertPool
-	InclSystemMetrics     bool
-	SkipTLSVerification   bool
-	SetClientName         bool
-	IsTile38              bool
-	ExportClientList      bool
-	ExportClientsInclPort bool
-	ConnectionTimeouts    time.Duration
-	MetricsPath           string
-	RedisMetricsOnly      bool
-	PingOnConnect         bool
-	Registry              *prometheus.Registry
-	BuildInfo             BuildInfo
+	User                    string
+	Password                string
+	Namespace               string
+	ConfigCommandName       string
+	CheckSingleKeys         string
+	CheckStreams            string
+	CheckSingleStreams      string
+	CheckKeys               string
+	CheckKeyGroups          string
+	CheckKeyGroupsBatchSize int64
+	MaxDistinctKeyGroups    int64
+	CountKeys               string
+	LuaScript               []byte
+	ClientCertificates      []tls.Certificate
+	CaCertificates          *x509.CertPool
+	InclSystemMetrics       bool
+	SkipTLSVerification     bool
+	SetClientName           bool
+	IsTile38                bool
+	ExportClientList        bool
+	ExportClientsInclPort   bool
+	ConnectionTimeouts      time.Duration
+	MetricsPath             string
+	RedisMetricsOnly        bool
+	PingOnConnect           bool
+	Registry                *prometheus.Registry
+	BuildInfo               BuildInfo
 }
 
 func (e *Exporter) scrapeHandler(w http.ResponseWriter, r *http.Request) {
@@ -438,50 +441,54 @@ func NewRedisExporter(redisURI string, opts Options) (*Exporter, error) {
 		txt  string
 		lbls []string
 	}{
-		"commands_duration_seconds_total":        {txt: `Total amount of time in seconds spent per command`, lbls: []string{"cmd"}},
-		"commands_total":                         {txt: `Total number of calls per command`, lbls: []string{"cmd"}},
-		"connected_slave_lag_seconds":            {txt: "Lag of connected slave", lbls: []string{"slave_ip", "slave_port", "slave_state"}},
-		"connected_slave_offset_bytes":           {txt: "Offset of connected slave", lbls: []string{"slave_ip", "slave_port", "slave_state"}},
-		"db_avg_ttl_seconds":                     {txt: "Avg TTL in seconds", lbls: []string{"db"}},
-		"db_keys":                                {txt: "Total number of keys by DB", lbls: []string{"db"}},
-		"db_keys_expiring":                       {txt: "Total number of expiring keys by DB", lbls: []string{"db"}},
-		"exporter_last_scrape_error":             {txt: "The last scrape error status.", lbls: []string{"err"}},
-		"instance_info":                          {txt: "Information about the Redis instance", lbls: []string{"role", "redis_version", "redis_build_id", "redis_mode", "os", "maxmemory_policy"}},
-		"key_size":                               {txt: `The length or size of "key"`, lbls: []string{"db", "key"}},
-		"key_value":                              {txt: `The value of "key"`, lbls: []string{"db", "key"}},
-		"keys_count":                             {txt: `Count of keys`, lbls: []string{"db", "key"}},
-		"last_slow_execution_duration_seconds":   {txt: `The amount of time needed for last slow execution, in seconds`},
-		"latency_spike_last":                     {txt: `When the latency spike last occurred`, lbls: []string{"event_name"}},
-		"latency_spike_duration_seconds":         {txt: `Length of the last latency spike in seconds`, lbls: []string{"event_name"}},
-		"master_link_up":                         {txt: "Master link status on Redis slave", lbls: []string{"master_host", "master_port"}},
-		"master_sync_in_progress":                {txt: "Master sync in progress", lbls: []string{"master_host", "master_port"}},
-		"master_last_io_seconds_ago":             {txt: "Master last io seconds ago", lbls: []string{"master_host", "master_port"}},
-		"script_values":                          {txt: "Values returned by the collect script", lbls: []string{"key"}},
-		"sentinel_tilt":                          {txt: "Sentinel is in TILT mode"},
-		"sentinel_masters":                       {txt: "The number of masters this sentinel is watching"},
-		"sentinel_running_scripts":               {txt: "Number of scripts in execution right now"},
-		"sentinel_scripts_queue_length":          {txt: "Queue of user scripts to execute"},
-		"sentinel_simulate_failure_flags":        {txt: "Failures simulations"},
-		"sentinel_master_status":                 {txt: "Master status on Sentinel", lbls: []string{"master_name", "master_address", "master_status"}},
-		"sentinel_master_slaves":                 {txt: "The number of slaves of the master", lbls: []string{"master_name", "master_address"}},
-		"sentinel_master_ok_slaves":              {txt: "The number of okay slaves of the master", lbls: []string{"master_name", "master_address"}},
-		"sentinel_master_sentinels":              {txt: "The number of sentinels monitoring this master", lbls: []string{"master_name", "master_address"}},
-		"sentinel_master_ok_sentinels":           {txt: "The number of okay sentinels monitoring this master", lbls: []string{"master_name", "master_address"}},
-		"slave_repl_offset":                      {txt: "Slave replication offset", lbls: []string{"master_host", "master_port"}},
-		"slave_info":                             {txt: "Information about the Redis slave", lbls: []string{"master_host", "master_port", "read_only"}},
-		"slowlog_last_id":                        {txt: `Last id of slowlog`},
-		"slowlog_length":                         {txt: `Total slowlog`},
-		"start_time_seconds":                     {txt: "Start time of the Redis instance since unix epoch in seconds."},
-		"stream_length":                          {txt: `The number of elements of the stream`, lbls: []string{"db", "stream"}},
-		"stream_radix_tree_keys":                 {txt: `Radix tree keys count"`, lbls: []string{"db", "stream"}},
-		"stream_radix_tree_nodes":                {txt: `Radix tree nodes count`, lbls: []string{"db", "stream"}},
-		"stream_groups":                          {txt: `Groups count of stream`, lbls: []string{"db", "stream"}},
-		"stream_group_consumers":                 {txt: `Consumers count of stream group`, lbls: []string{"db", "stream", "group"}},
-		"stream_group_messages_pending":          {txt: `Pending number of messages in that stream group`, lbls: []string{"db", "stream", "group"}},
-		"stream_group_consumer_messages_pending": {txt: `Pending number of messages for this specific consumer`, lbls: []string{"db", "stream", "group", "consumer"}},
-		"stream_group_consumer_idle_seconds":     {txt: `Consumer idle time in seconds`, lbls: []string{"db", "stream", "group", "consumer"}},
-		"up":                                     {txt: "Information about the Redis instance"},
-		"connected_clients_details":              {txt: "Details about connected clients", lbls: connectedClientsLabels},
+		"commands_duration_seconds_total":              {txt: `Total amount of time in seconds spent per command`, lbls: []string{"cmd"}},
+		"commands_total":                               {txt: `Total number of calls per command`, lbls: []string{"cmd"}},
+		"connected_slave_lag_seconds":                  {txt: "Lag of connected slave", lbls: []string{"slave_ip", "slave_port", "slave_state"}},
+		"connected_slave_offset_bytes":                 {txt: "Offset of connected slave", lbls: []string{"slave_ip", "slave_port", "slave_state"}},
+		"db_avg_ttl_seconds":                           {txt: "Avg TTL in seconds", lbls: []string{"db"}},
+		"db_keys":                                      {txt: "Total number of keys by DB", lbls: []string{"db"}},
+		"db_keys_expiring":                             {txt: "Total number of expiring keys by DB", lbls: []string{"db"}},
+		"exporter_last_scrape_error":                   {txt: "The last scrape error status.", lbls: []string{"err"}},
+		"instance_info":                                {txt: "Information about the Redis instance", lbls: []string{"role", "redis_version", "redis_build_id", "redis_mode", "os", "maxmemory_policy"}},
+		"key_group_count":                              {txt: `Count of keys in key group`, lbls: []string{"db", "key_group"}},
+		"key_group_memory_usage_bytes":                 {txt: `Total memory usage of key group in bytes`, lbls: []string{"db", "key_group"}},
+		"key_size":                                     {txt: `The length or size of "key"`, lbls: []string{"db", "key"}},
+		"key_value":                                    {txt: `The value of "key"`, lbls: []string{"db", "key"}},
+		"keys_count":                                   {txt: `Count of keys`, lbls: []string{"db", "key"}},
+		"number_of_distinct_key_groups":                {txt: `Number of distinct key groups`, lbls: []string{"db"}},
+		"last_key_groups_scrape_duration_milliseconds": {txt: `Duration of the last key group metrics scrape in milliseconds`},
+		"last_slow_execution_duration_seconds":         {txt: `The amount of time needed for last slow execution, in seconds`},
+		"latency_spike_last":                           {txt: `When the latency spike last occurred`, lbls: []string{"event_name"}},
+		"latency_spike_duration_seconds":               {txt: `Length of the last latency spike in seconds`, lbls: []string{"event_name"}},
+		"master_link_up":                               {txt: "Master link status on Redis slave", lbls: []string{"master_host", "master_port"}},
+		"master_sync_in_progress":                      {txt: "Master sync in progress", lbls: []string{"master_host", "master_port"}},
+		"master_last_io_seconds_ago":                   {txt: "Master last io seconds ago", lbls: []string{"master_host", "master_port"}},
+		"script_values":                                {txt: "Values returned by the collect script", lbls: []string{"key"}},
+		"sentinel_tilt":                                {txt: "Sentinel is in TILT mode"},
+		"sentinel_masters":                             {txt: "The number of masters this sentinel is watching"},
+		"sentinel_running_scripts":                     {txt: "Number of scripts in execution right now"},
+		"sentinel_scripts_queue_length":                {txt: "Queue of user scripts to execute"},
+		"sentinel_simulate_failure_flags":              {txt: "Failures simulations"},
+		"sentinel_master_status":                       {txt: "Master status on Sentinel", lbls: []string{"master_name", "master_address", "master_status"}},
+		"sentinel_master_slaves":                       {txt: "The number of slaves of the master", lbls: []string{"master_name", "master_address"}},
+		"sentinel_master_ok_slaves":                    {txt: "The number of okay slaves of the master", lbls: []string{"master_name", "master_address"}},
+		"sentinel_master_sentinels":                    {txt: "The number of sentinels monitoring this master", lbls: []string{"master_name", "master_address"}},
+		"sentinel_master_ok_sentinels":                 {txt: "The number of okay sentinels monitoring this master", lbls: []string{"master_name", "master_address"}},
+		"slave_repl_offset":                            {txt: "Slave replication offset", lbls: []string{"master_host", "master_port"}},
+		"slave_info":                                   {txt: "Information about the Redis slave", lbls: []string{"master_host", "master_port", "read_only"}},
+		"slowlog_last_id":                              {txt: `Last id of slowlog`},
+		"slowlog_length":                               {txt: `Total slowlog`},
+		"start_time_seconds":                           {txt: "Start time of the Redis instance since unix epoch in seconds."},
+		"stream_length":                                {txt: `The number of elements of the stream`, lbls: []string{"db", "stream"}},
+		"stream_radix_tree_keys":                       {txt: `Radix tree keys count"`, lbls: []string{"db", "stream"}},
+		"stream_radix_tree_nodes":                      {txt: `Radix tree nodes count`, lbls: []string{"db", "stream"}},
+		"stream_groups":                                {txt: `Groups count of stream`, lbls: []string{"db", "stream"}},
+		"stream_group_consumers":                       {txt: `Consumers count of stream group`, lbls: []string{"db", "stream", "group"}},
+		"stream_group_messages_pending":                {txt: `Pending number of messages in that stream group`, lbls: []string{"db", "stream", "group"}},
+		"stream_group_consumer_messages_pending":       {txt: `Pending number of messages for this specific consumer`, lbls: []string{"db", "stream", "group", "consumer"}},
+		"stream_group_consumer_idle_seconds":           {txt: `Consumer idle time in seconds`, lbls: []string{"db", "stream", "group", "consumer"}},
+		"up":                                           {txt: "Information about the Redis instance"},
+		"connected_clients_details":                    {txt: "Details about connected clients", lbls: connectedClientsLabels},
 	} {
 		e.metricDescriptions[k] = newMetricDescr(opts.Namespace, k, desc.txt, desc.lbls)
 	}
@@ -1047,7 +1054,6 @@ func (e *Exporter) extractClusterInfoMetrics(ch chan<- prometheus.Metric, info s
 		if !e.includeMetric(fieldKey) {
 			continue
 		}
-
 		e.parseAndRegisterConstMetric(ch, fieldKey, fieldValue)
 	}
 }
@@ -1664,6 +1670,8 @@ func (e *Exporter) scrapeRedisHost(ch chan<- prometheus.Metric) error {
 	if strings.Contains(infoAll, "# Sentinel") {
 		e.extractSentinelMetrics(ch, c)
 	}
+
+	e.extractKeyGroupMetrics(ch, c, dbCount)
 
 	if e.options.LuaScript != nil && len(e.options.LuaScript) > 0 {
 		if err := e.extractLuaScriptMetrics(ch, c); err != nil {

--- a/exporter/key_groups.go
+++ b/exporter/key_groups.go
@@ -1,0 +1,236 @@
+package exporter
+
+import (
+	"encoding/csv"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/gomodule/redigo/redis"
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+)
+
+type keyGroupMetrics struct {
+	keyGroup    string
+	count       int64
+	memoryUsage int64
+}
+
+type overflowedKeyGroupMetrics struct {
+	topMemoryUsageKeyGroups   []*keyGroupMetrics
+	overflowKeyGroupAggregate keyGroupMetrics
+	keyGroupsCount            int64
+}
+
+type keyGroupsScrapeResult struct {
+	duration          time.Duration
+	metrics           []map[string]*keyGroupMetrics
+	overflowedMetrics []*overflowedKeyGroupMetrics
+}
+
+func (e *Exporter) extractKeyGroupMetrics(ch chan<- prometheus.Metric, c redis.Conn, dbCount int) {
+	allDbKeyGroupMetrics := e.gatherKeyGroupsMetricsForAllDatabases(c, dbCount)
+	if allDbKeyGroupMetrics == nil {
+		return
+	}
+	for db, dbKeyGroupMetrics := range allDbKeyGroupMetrics.metrics {
+		dbLabel := fmt.Sprintf("db%d", db)
+		registerKeyGroupMetrics := func(metrics *keyGroupMetrics) {
+			e.registerConstMetricGauge(
+				ch,
+				"key_group_count",
+				float64(metrics.count),
+				dbLabel,
+				metrics.keyGroup,
+			)
+			e.registerConstMetricGauge(
+				ch,
+				"key_group_memory_usage_bytes",
+				float64(metrics.memoryUsage),
+				dbLabel,
+				metrics.keyGroup,
+			)
+		}
+		if allDbKeyGroupMetrics.overflowedMetrics[db] != nil {
+			overflowedMetrics := allDbKeyGroupMetrics.overflowedMetrics[db]
+			for _, metrics := range overflowedMetrics.topMemoryUsageKeyGroups {
+				registerKeyGroupMetrics(metrics)
+			}
+			registerKeyGroupMetrics(&overflowedMetrics.overflowKeyGroupAggregate)
+			e.registerConstMetricGauge(ch, "number_of_distinct_key_groups", float64(overflowedMetrics.keyGroupsCount), dbLabel)
+		} else if dbKeyGroupMetrics != nil {
+			for _, metrics := range dbKeyGroupMetrics {
+				registerKeyGroupMetrics(metrics)
+			}
+			e.registerConstMetricGauge(ch, "number_of_distinct_key_groups", float64(len(dbKeyGroupMetrics)), dbLabel)
+		}
+	}
+	e.registerConstMetricGauge(ch, "last_key_groups_scrape_duration_milliseconds", float64(allDbKeyGroupMetrics.duration.Milliseconds()))
+}
+
+func (e *Exporter) gatherKeyGroupsMetricsForAllDatabases(c redis.Conn, dbCount int) *keyGroupsScrapeResult {
+	start := time.Now()
+	allMetrics := &keyGroupsScrapeResult{
+		metrics:           make([]map[string]*keyGroupMetrics, dbCount, dbCount),
+		overflowedMetrics: make([]*overflowedKeyGroupMetrics, dbCount, dbCount),
+	}
+	defer func() {
+		allMetrics.duration = time.Since(start)
+	}()
+	if strings.TrimSpace(e.options.CheckKeyGroups) == "" {
+		return allMetrics
+	}
+	keyGroups, err := csv.NewReader(
+		strings.NewReader(e.options.CheckKeyGroups),
+	).Read()
+	if err != nil {
+		log.Errorf("Failed to parse key groups as csv: %s", err)
+		return allMetrics
+	}
+	for i, v := range keyGroups {
+		keyGroups[i] = strings.TrimSpace(v)
+	}
+
+	keyGroupsNoEmptyStrings := make([]string, 0)
+	for _, v := range keyGroups {
+		if len(v) > 0 {
+			keyGroupsNoEmptyStrings = append(keyGroupsNoEmptyStrings, v)
+		}
+	}
+	if len(keyGroupsNoEmptyStrings) == 0 {
+		return allMetrics
+	}
+	for db := 0; db < dbCount; db++ {
+		if _, err := doRedisCmd(c, "SELECT", db); err != nil {
+			log.Errorf("Couldn't select database %d when getting key info.", db)
+			continue
+		}
+		allGroups, err := gatherKeyGroupMetrics(c, e.options.CheckKeyGroupsBatchSize, keyGroupsNoEmptyStrings)
+		if err != nil {
+			log.Error(err)
+			continue
+		}
+		allMetrics.metrics[db] = allGroups
+		if int64(len(allGroups)) > e.options.MaxDistinctKeyGroups {
+			metricsSlice := make([]*keyGroupMetrics, 0, len(allGroups))
+			for _, v := range allGroups {
+				metricsSlice = append(metricsSlice, v)
+			}
+			sort.Slice(metricsSlice, func(i, j int) bool {
+				if metricsSlice[i].memoryUsage == metricsSlice[j].memoryUsage {
+					if metricsSlice[i].count == metricsSlice[j].count {
+						return metricsSlice[i].keyGroup < metricsSlice[j].keyGroup
+					}
+					return metricsSlice[i].count < metricsSlice[j].count
+				}
+				return metricsSlice[i].memoryUsage > metricsSlice[j].memoryUsage
+			})
+			var overflowedCount, overflowedMemoryUsage int64
+			for _, v := range metricsSlice[e.options.MaxDistinctKeyGroups:] {
+				overflowedCount += v.count
+				overflowedMemoryUsage += v.memoryUsage
+			}
+			allMetrics.overflowedMetrics[db] = &overflowedKeyGroupMetrics{
+				topMemoryUsageKeyGroups: metricsSlice[:e.options.MaxDistinctKeyGroups],
+				overflowKeyGroupAggregate: keyGroupMetrics{
+					keyGroup:    "overflow",
+					count:       overflowedCount,
+					memoryUsage: overflowedMemoryUsage,
+				},
+				keyGroupsCount: int64(len(allGroups)),
+			}
+		}
+	}
+	return allMetrics
+}
+
+func gatherKeyGroupMetrics(c redis.Conn, batchSize int64, keyGroups []string) (map[string]*keyGroupMetrics, error) {
+	allGroups := make(map[string]*keyGroupMetrics)
+	keysAndArgs := []interface{}{0, batchSize}
+	for _, keyGroup := range keyGroups {
+		keysAndArgs = append(keysAndArgs, keyGroup)
+	}
+
+	script := redis.NewScript(
+		0,
+		`
+local result = {}
+local batch = redis.call("SCAN", ARGV[1], "COUNT", ARGV[2])
+local groups = {}
+local usage = 0
+local group_index = 0
+local group = nil
+local value = {}
+local key_match_result = {}
+local status = false
+local err = nil
+for i=3,#ARGV do
+  status, err = pcall(string.find, " ", ARGV[i])
+  if not status then
+    error(err .. ARGV[i])
+  end
+end
+for i,key in ipairs(batch[2]) do
+  usage = redis.call("MEMORY", "USAGE", key)
+  group = nil
+  for i=3,#ARGV do
+    key_match_result = {string.find(key, ARGV[i])}
+    if key_match_result[1] ~= nil then
+      group = table.concat({unpack(key_match_result, 3,  #key_match_result)},  "")
+      break
+    end
+  end
+  if group == nil then
+     group = "unclassified"
+  end
+  value = groups[group]
+  if value == nil then
+     groups[group] = {1, usage}
+  else
+     groups[group] = {value[1] + 1, value[2] + usage}
+  end
+end
+for group,value in pairs(groups) do
+  result[#result+1] = {group, value[1], value[2]}
+end
+return {batch[1], result}`,
+	)
+
+	for {
+		arr, err := redis.Values(script.Do(c, keysAndArgs...))
+		if err != nil {
+			return nil, err
+		}
+
+		if len(arr) != 2 {
+			return nil, fmt.Errorf("invalid response from key group metrics lua script for groups: %s", strings.Join(keyGroups, ", "))
+		}
+
+		groups, _ := redis.Values(arr[1], nil)
+
+		for _, group := range groups {
+			metricsArr, _ := redis.Values(group, nil)
+			name, _ := redis.String(metricsArr[0], nil)
+			count, _ := redis.Int64(metricsArr[1], nil)
+			memoryUsage, _ := redis.Int64(metricsArr[2], nil)
+
+			if currentMetrics, ok := allGroups[name]; ok {
+				currentMetrics.count += count
+				currentMetrics.memoryUsage += memoryUsage
+			} else {
+				allGroups[name] = &keyGroupMetrics{
+					keyGroup:    name,
+					count:       count,
+					memoryUsage: memoryUsage,
+				}
+			}
+
+		}
+		if keysAndArgs[0], _ = redis.Int(arr[0], nil); keysAndArgs[0].(int) == 0 {
+			break
+		}
+	}
+	return allGroups, nil
+}

--- a/exporter/key_groups_test.go
+++ b/exporter/key_groups_test.go
@@ -1,0 +1,177 @@
+package exporter
+
+import (
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gomodule/redigo/redis"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func getDBCount(c redis.Conn) (dbCount int, err error) {
+	dbCount = 16
+	var config []string
+	if config, err = redis.Strings(doRedisCmd(c, "CONFIG", "GET", "*")); err != nil {
+		return
+	}
+
+	for pos := 0; pos < len(config)/2; pos++ {
+		strKey := config[pos*2]
+		strVal := config[pos*2+1]
+
+		if strKey == "databases" {
+			if dbCount, err = strconv.Atoi(strVal); err != nil {
+				dbCount = 16
+			}
+			return
+		}
+	}
+	return
+}
+
+type keyGroupData struct {
+	name                   string
+	checkKeyGroups         string
+	maxDistinctKeyGroups   int64
+	wantedCount            map[string]int
+	wantedMemory           map[string]bool
+	wantedDistintKeyGroups int
+}
+
+func TestKeyGroupMetrics(t *testing.T) {
+	if os.Getenv("TEST_REDIS_URI") == "" {
+		t.Skipf("TEST_REDIS_URI not set - skipping")
+	}
+	addr := os.Getenv("TEST_REDIS_URI")
+	c, err := redis.DialURL(addr)
+	if err != nil {
+		t.Fatalf("Couldn't connect to %#v: %#v", addr, err)
+	}
+
+	var dbCount int
+	if dbCount, err = getDBCount(c); err != nil {
+		t.Fatalf("Couldn't get dbCount: %#v", err)
+	}
+	setupDBKeys(t, addr)
+	defer deleteKeysFromDB(t, addr)
+
+	tsts := []keyGroupData{
+		{
+			name:                 "synchronous with unclassified keys",
+			checkKeyGroups:       "^(key_ringo)_[0-9]+$,^(key_paul)_[0-9]+$,^(key_exp)_.+$",
+			maxDistinctKeyGroups: 100,
+			// The actual counts are a function of keys (all types) being set up in the init() function
+			// and the CheckKeyGroups regexes for initializing the Redis exporter above. The count below
+			// will need to be updated if either of the aforementioned things have changed.
+			wantedCount: map[string]int{
+				"key_ringo":    1,
+				"key_paul":     1,
+				"unclassified": 5,
+				"key_exp":      5,
+			},
+			wantedMemory: map[string]bool{
+				"key_ringo":    true,
+				"key_paul":     true,
+				"unclassified": true,
+				"key_exp":      true,
+			},
+			wantedDistintKeyGroups: 4,
+		},
+		{
+			name:                 "synchronous with overflow keys",
+			checkKeyGroups:       "^(.*)$", // Each key is a distinct key group
+			maxDistinctKeyGroups: 1,
+			// The actual counts depend on the largest key being set up in the init()
+			// function (test-stream at the time this code was written) and the total
+			// of keys (all types). This will need to be updated to match future
+			// updates of the init() function
+			wantedCount: map[string]int{
+				"test-stream": 1,
+				"overflow":    11,
+			},
+			wantedMemory: map[string]bool{
+				"test-stream": true,
+				"overflow":    true,
+			},
+			wantedDistintKeyGroups: 12,
+		},
+	}
+
+	for _, tst := range tsts {
+		t.Run(tst.name, func(t *testing.T) {
+			e, _ := NewRedisExporter(
+				addr,
+				Options{
+					Namespace:               "test",
+					CheckKeyGroups:          tst.checkKeyGroups,
+					CheckKeyGroupsBatchSize: 1000,
+					MaxDistinctKeyGroups:    tst.maxDistinctKeyGroups,
+				},
+			)
+			for {
+				chM := make(chan prometheus.Metric)
+				go func() {
+					e.extractKeyGroupMetrics(chM, c, dbCount)
+					close(chM)
+				}()
+
+				actualCount := make(map[string]int)
+				actualMemory := make(map[string]bool)
+				actualDistinctKeyGroups := 0
+
+				receivedMetrics := false
+				for m := range chM {
+					receivedMetrics = true
+					got := &dto.Metric{}
+					m.Write(got)
+
+					if strings.Contains(m.Desc().String(), "test_key_group_count") {
+						for _, label := range got.GetLabel() {
+							if *label.Name == "key_group" {
+								actualCount[*label.Value] = int(*got.Gauge.Value)
+							}
+						}
+					} else if strings.Contains(m.Desc().String(), "test_key_group_memory_usage_bytes") {
+						for _, label := range got.GetLabel() {
+							if *label.Name == "key_group" {
+								actualMemory[*label.Value] = true
+							}
+						}
+					} else if strings.Contains(m.Desc().String(), "test_number_of_distinct_key_groups") {
+						for _, label := range got.GetLabel() {
+							if *label.Name == "db" && *label.Value == "db"+dbNumStr {
+								actualDistinctKeyGroups = int(*got.Gauge.Value)
+							}
+						}
+					}
+				}
+
+				if !receivedMetrics {
+					time.Sleep(100 * time.Millisecond)
+					continue
+				}
+				if !reflect.DeepEqual(tst.wantedCount, actualCount) {
+					t.Errorf("Key group count metrics are not expected:\n Expected: %#v\nActual: %#v\n", tst.wantedCount, actualCount)
+				}
+
+				// It's a little fragile to anticipate how much memory
+				// will be allocated for specific key groups, so we
+				// are only going to check for presence of memory usage
+				// metrics for expected key groups here.
+				if !reflect.DeepEqual(tst.wantedMemory, actualMemory) {
+					t.Errorf("Key group memory usage metrics are not expected:\n Expected: %#v\nActual: %#v\n", tst.wantedMemory, actualMemory)
+				}
+
+				if actualDistinctKeyGroups != tst.wantedDistintKeyGroups {
+					t.Errorf("Unexpected number of distinct key groups, expected: %d, actual: %d", tst.wantedDistintKeyGroups, actualDistinctKeyGroups)
+				}
+				break
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -43,38 +43,51 @@ func getEnvBool(key string, defaultVal bool) bool {
 	return defaultVal
 }
 
+func getEnvInt64(key string, defaultVal int64) int64 {
+	if envVal, ok := os.LookupEnv(key); ok {
+		envInt64, err := strconv.ParseInt(envVal, 10, 64)
+		if err == nil {
+			return envInt64
+		}
+	}
+	return defaultVal
+}
+
 func main() {
 	var (
-		redisAddr           = flag.String("redis.addr", getEnv("REDIS_ADDR", "redis://localhost:6379"), "Address of the Redis instance to scrape")
-		redisUser           = flag.String("redis.user", getEnv("REDIS_USER", ""), "User name to use for authentication (Redis ACL for Redis 6.0 and newer)")
-		redisPwd            = flag.String("redis.password", getEnv("REDIS_PASSWORD", ""), "Password of the Redis instance to scrape")
-		namespace           = flag.String("namespace", getEnv("REDIS_EXPORTER_NAMESPACE", "redis"), "Namespace for metrics")
-		checkKeys           = flag.String("check-keys", getEnv("REDIS_EXPORTER_CHECK_KEYS", ""), "Comma separated list of key-patterns to export value and length/size, searched for with SCAN")
-		checkSingleKeys     = flag.String("check-single-keys", getEnv("REDIS_EXPORTER_CHECK_SINGLE_KEYS", ""), "Comma separated list of single keys to export value and length/size")
-		checkStreams        = flag.String("check-streams", getEnv("REDIS_EXPORTER_CHECK_STREAMS", ""), "Comma separated list of stream-patterns to export info about streams, groups and consumers, searched for with SCAN")
-		checkSingleStreams  = flag.String("check-single-streams", getEnv("REDIS_EXPORTER_CHECK_SINGLE_STREAMS", ""), "Comma separated list of single streams to export info about streams, groups and consumers")
-		countKeys           = flag.String("count-keys", getEnv("REDIS_EXPORTER_COUNT_KEYS", ""), "Comma separated list of patterns to count, eg: 'db3=sessions:*'. Warning: The exporter runs SCAN to count the keys.")
-		scriptPath          = flag.String("script", getEnv("REDIS_EXPORTER_SCRIPT", ""), "Path to Lua Redis script for collecting extra metrics")
-		listenAddress       = flag.String("web.listen-address", getEnv("REDIS_EXPORTER_WEB_LISTEN_ADDRESS", ":9121"), "Address to listen on for web interface and telemetry.")
-		metricPath          = flag.String("web.telemetry-path", getEnv("REDIS_EXPORTER_WEB_TELEMETRY_PATH", "/metrics"), "Path under which to expose metrics.")
-		logFormat           = flag.String("log-format", getEnv("REDIS_EXPORTER_LOG_FORMAT", "txt"), "Log format, valid options are txt and json")
-		configCommand       = flag.String("config-command", getEnv("REDIS_EXPORTER_CONFIG_COMMAND", "CONFIG"), "What to use for the CONFIG command")
-		connectionTimeout   = flag.String("connection-timeout", getEnv("REDIS_EXPORTER_CONNECTION_TIMEOUT", "15s"), "Timeout for connection to Redis instance")
-		tlsClientKeyFile    = flag.String("tls-client-key-file", getEnv("REDIS_EXPORTER_TLS_CLIENT_KEY_FILE", ""), "Name of the client key file (including full path) if the server requires TLS client authentication")
-		tlsClientCertFile   = flag.String("tls-client-cert-file", getEnv("REDIS_EXPORTER_TLS_CLIENT_CERT_FILE", ""), "Name of the client certificate file (including full path) if the server requires TLS client authentication")
-		tlsCaCertFile       = flag.String("tls-ca-cert-file", getEnv("REDIS_EXPORTER_TLS_CA_CERT_FILE", ""), "Name of the CA certificate file (including full path) if the server requires TLS client authentication")
-		tlsServerKeyFile    = flag.String("tls-server-key-file", getEnv("REDIS_EXPORTER_TLS_SERVER_KEY_FILE", ""), "Name of the server key file (including full path) if the web interface and telemetry should use TLS")
-		tlsServerCertFile   = flag.String("tls-server-cert-file", getEnv("REDIS_EXPORTER_TLS_SERVER_CERT_FILE", ""), "Name of the server certificate file (including full path) if the web interface and telemetry should use TLS")
-		isDebug             = flag.Bool("debug", getEnvBool("REDIS_EXPORTER_DEBUG", false), "Output verbose debug information")
-		setClientName       = flag.Bool("set-client-name", getEnvBool("REDIS_EXPORTER_SET_CLIENT_NAME", true), "Whether to set client name to redis_exporter")
-		isTile38            = flag.Bool("is-tile38", getEnvBool("REDIS_EXPORTER_IS_TILE38", false), "Whether to scrape Tile38 specific metrics")
-		exportClientList    = flag.Bool("export-client-list", getEnvBool("REDIS_EXPORTER_EXPORT_CLIENT_LIST", false), "Whether to scrape Client List specific metrics")
-		exportClientPort    = flag.Bool("export-client-port", getEnvBool("REDIS_EXPORTER_EXPORT_CLIENT_PORT", false), "Whether to include the client's port when exporting the client list. Warning: including the port increases the number of metrics generated and will make your Prometheus server take up more memory")
-		showVersion         = flag.Bool("version", false, "Show version information and exit")
-		redisMetricsOnly    = flag.Bool("redis-only-metrics", getEnvBool("REDIS_EXPORTER_REDIS_ONLY_METRICS", false), "Whether to also export go runtime metrics")
-		pingOnConnect       = flag.Bool("ping-on-connect", getEnvBool("REDIS_EXPORTER_PING_ON_CONNECT", false), "Whether to ping the redis instance after connecting")
-		inclSystemMetrics   = flag.Bool("include-system-metrics", getEnvBool("REDIS_EXPORTER_INCL_SYSTEM_METRICS", false), "Whether to include system metrics like e.g. redis_total_system_memory_bytes")
-		skipTLSVerification = flag.Bool("skip-tls-verification", getEnvBool("REDIS_EXPORTER_SKIP_TLS_VERIFICATION", false), "Whether to to skip TLS verification")
+		redisAddr               = flag.String("redis.addr", getEnv("REDIS_ADDR", "redis://localhost:6379"), "Address of the Redis instance to scrape")
+		redisUser               = flag.String("redis.user", getEnv("REDIS_USER", ""), "User name to use for authentication (Redis ACL for Redis 6.0 and newer)")
+		redisPwd                = flag.String("redis.password", getEnv("REDIS_PASSWORD", ""), "Password of the Redis instance to scrape")
+		namespace               = flag.String("namespace", getEnv("REDIS_EXPORTER_NAMESPACE", "redis"), "Namespace for metrics")
+		checkKeys               = flag.String("check-keys", getEnv("REDIS_EXPORTER_CHECK_KEYS", ""), "Comma separated list of key-patterns to export value and length/size, searched for with SCAN")
+		checkSingleKeys         = flag.String("check-single-keys", getEnv("REDIS_EXPORTER_CHECK_SINGLE_KEYS", ""), "Comma separated list of single keys to export value and length/size")
+		checkKeyGroups          = flag.String("check-key-groups", getEnv("REDIS_EXPORTER_CHECK_KEY_GROUPS", ""), "Comma separated list of lua regex for grouping keys")
+		checkStreams            = flag.String("check-streams", getEnv("REDIS_EXPORTER_CHECK_STREAMS", ""), "Comma separated list of stream-patterns to export info about streams, groups and consumers, searched for with SCAN")
+		checkSingleStreams      = flag.String("check-single-streams", getEnv("REDIS_EXPORTER_CHECK_SINGLE_STREAMS", ""), "Comma separated list of single streams to export info about streams, groups and consumers")
+		countKeys               = flag.String("count-keys", getEnv("REDIS_EXPORTER_COUNT_KEYS", ""), "Comma separated list of patterns to count, eg: 'db3=sessions:*'. Warning: The exporter runs SCAN to count the keys.")
+		scriptPath              = flag.String("script", getEnv("REDIS_EXPORTER_SCRIPT", ""), "Path to Lua Redis script for collecting extra metrics")
+		listenAddress           = flag.String("web.listen-address", getEnv("REDIS_EXPORTER_WEB_LISTEN_ADDRESS", ":9121"), "Address to listen on for web interface and telemetry.")
+		metricPath              = flag.String("web.telemetry-path", getEnv("REDIS_EXPORTER_WEB_TELEMETRY_PATH", "/metrics"), "Path under which to expose metrics.")
+		logFormat               = flag.String("log-format", getEnv("REDIS_EXPORTER_LOG_FORMAT", "txt"), "Log format, valid options are txt and json")
+		configCommand           = flag.String("config-command", getEnv("REDIS_EXPORTER_CONFIG_COMMAND", "CONFIG"), "What to use for the CONFIG command")
+		connectionTimeout       = flag.String("connection-timeout", getEnv("REDIS_EXPORTER_CONNECTION_TIMEOUT", "15s"), "Timeout for connection to Redis instance")
+		tlsClientKeyFile        = flag.String("tls-client-key-file", getEnv("REDIS_EXPORTER_TLS_CLIENT_KEY_FILE", ""), "Name of the client key file (including full path) if the server requires TLS client authentication")
+		tlsClientCertFile       = flag.String("tls-client-cert-file", getEnv("REDIS_EXPORTER_TLS_CLIENT_CERT_FILE", ""), "Name of the client certificate file (including full path) if the server requires TLS client authentication")
+		tlsCaCertFile           = flag.String("tls-ca-cert-file", getEnv("REDIS_EXPORTER_TLS_CA_CERT_FILE", ""), "Name of the CA certificate file (including full path) if the server requires TLS client authentication")
+		tlsServerKeyFile        = flag.String("tls-server-key-file", getEnv("REDIS_EXPORTER_TLS_SERVER_KEY_FILE", ""), "Name of the server key file (including full path) if the web interface and telemetry should use TLS")
+		tlsServerCertFile       = flag.String("tls-server-cert-file", getEnv("REDIS_EXPORTER_TLS_SERVER_CERT_FILE", ""), "Name of the server certificate file (including full path) if the web interface and telemetry should use TLS")
+		checkKeyGroupsBatchSize = flag.Int64("check-key-groups-batch-size", getEnvInt64("REDIS_EXPORTER_CHECK_KEY_GROUPS_BATCH_SIZE", 10000), "Check key groups batch size hint for the underlying SCAN")
+		maxDistinctKeyGroups    = flag.Int64("max-distinct-key-groups", getEnvInt64("REDIS_EXPORTER_MAX_DISTINCT_KEY_GROUPS", 100), "The maximum number of distinct key groups with the most memory utilization to present as distinct metrics per database, the leftover key groups will be aggregated in the 'overflow' bucket")
+		isDebug                 = flag.Bool("debug", getEnvBool("REDIS_EXPORTER_DEBUG", false), "Output verbose debug information")
+		setClientName           = flag.Bool("set-client-name", getEnvBool("REDIS_EXPORTER_SET_CLIENT_NAME", true), "Whether to set client name to redis_exporter")
+		isTile38                = flag.Bool("is-tile38", getEnvBool("REDIS_EXPORTER_IS_TILE38", false), "Whether to scrape Tile38 specific metrics")
+		exportClientList        = flag.Bool("export-client-list", getEnvBool("REDIS_EXPORTER_EXPORT_CLIENT_LIST", false), "Whether to scrape Client List specific metrics")
+		exportClientPort        = flag.Bool("export-client-port", getEnvBool("REDIS_EXPORTER_EXPORT_CLIENT_PORT", false), "Whether to include the client's port when exporting the client list. Warning: including the port increases the number of metrics generated and will make your Prometheus server take up more memory")
+		showVersion             = flag.Bool("version", false, "Show version information and exit")
+		redisMetricsOnly        = flag.Bool("redis-only-metrics", getEnvBool("REDIS_EXPORTER_REDIS_ONLY_METRICS", false), "Whether to also export go runtime metrics")
+		pingOnConnect           = flag.Bool("ping-on-connect", getEnvBool("REDIS_EXPORTER_PING_ON_CONNECT", false), "Whether to ping the redis instance after connecting")
+		inclSystemMetrics       = flag.Bool("include-system-metrics", getEnvBool("REDIS_EXPORTER_INCL_SYSTEM_METRICS", false), "Whether to include system metrics like e.g. redis_total_system_memory_bytes")
+		skipTLSVerification     = flag.Bool("skip-tls-verification", getEnvBool("REDIS_EXPORTER_SKIP_TLS_VERIFICATION", false), "Whether to to skip TLS verification")
 	)
 	flag.Parse()
 
@@ -143,29 +156,32 @@ func main() {
 	exp, err := exporter.NewRedisExporter(
 		*redisAddr,
 		exporter.Options{
-			User:                  *redisUser,
-			Password:              *redisPwd,
-			Namespace:             *namespace,
-			ConfigCommandName:     *configCommand,
-			CheckKeys:             *checkKeys,
-			CheckSingleKeys:       *checkSingleKeys,
-			CheckStreams:          *checkStreams,
-			CheckSingleStreams:    *checkSingleStreams,
-			CountKeys:             *countKeys,
-			LuaScript:             ls,
-			InclSystemMetrics:     *inclSystemMetrics,
-			SetClientName:         *setClientName,
-			IsTile38:              *isTile38,
-			ExportClientList:      *exportClientList,
-			ExportClientsInclPort: *exportClientPort,
-			SkipTLSVerification:   *skipTLSVerification,
-			ClientCertificates:    tlsClientCertificates,
-			CaCertificates:        tlsCaCertificates,
-			ConnectionTimeouts:    to,
-			MetricsPath:           *metricPath,
-			RedisMetricsOnly:      *redisMetricsOnly,
-			PingOnConnect:         *pingOnConnect,
-			Registry:              registry,
+			User:                    *redisUser,
+			Password:                *redisPwd,
+			Namespace:               *namespace,
+			ConfigCommandName:       *configCommand,
+			CheckKeys:               *checkKeys,
+			CheckSingleKeys:         *checkSingleKeys,
+			CheckKeyGroups:          *checkKeyGroups,
+			CheckKeyGroupsBatchSize: *checkKeyGroupsBatchSize,
+			MaxDistinctKeyGroups:    *maxDistinctKeyGroups,
+			CheckStreams:            *checkStreams,
+			CheckSingleStreams:      *checkSingleStreams,
+			CountKeys:               *countKeys,
+			LuaScript:               ls,
+			InclSystemMetrics:       *inclSystemMetrics,
+			SetClientName:           *setClientName,
+			IsTile38:                *isTile38,
+			ExportClientList:        *exportClientList,
+			ExportClientsInclPort:   *exportClientPort,
+			SkipTLSVerification:     *skipTLSVerification,
+			ClientCertificates:      tlsClientCertificates,
+			CaCertificates:          tlsCaCertificates,
+			ConnectionTimeouts:      to,
+			MetricsPath:             *metricPath,
+			RedisMetricsOnly:        *redisMetricsOnly,
+			PingOnConnect:           *pingOnConnect,
+			Registry:                registry,
 			BuildInfo: exporter.BuildInfo{
 				Version:   BuildVersion,
 				CommitSha: BuildCommitSha,


### PR DESCRIPTION
Hello redis_exporter maintainer,

I am hoping to upstream an enhancement via this PR that I have been using for my local environments for tracking Redis memory usage by key groups as determined through a user-defined list of (LUA) regular expressions. I understand that such capability is available to some extent through the check-keys, check-single-keys, and count-keys parameters, so I have included a somewhat detailed explanation of how the enhancement work in the README which will hopefully convince the redis_exporter community that this is a useful enhancement to be incorporated into the official redis_exporter.

I have certainly enjoyed using redis_exporter, and I hope that I can give back a bit to the community through this PR.