### PR TITLE
allow configuring whether to include the client port

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -31,9 +31,9 @@ services:
   - name: pwd-redis6
     image: redis:6
     commands:
-      - "redis-server --port 6390 --requirepass dummy --user exporter on +INFO +SELECT +SLOWLOG +LATENCY '>exporter-password' --dbfilename dump6-pwd.rdb"
+      - "redis-server --port 6390 --requirepass dummy --user exporter on +INFO +CLIENT +SELECT +SLOWLOG +LATENCY '>exporter-password' --dbfilename dump6-pwd.rdb"
     ports:
-      - 6380
+      - 6390
 
   - name: redis-2-8
     image: redis:2.8

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ test:
 	TEST_REDIS_CLUSTER_SLAVE_URI="redis://redis-cluster:7005" \
 	TEST_TILE38_URI="redis://tile38:9851" \
 	TEST_REDIS_SENTINEL_URI="redis://redis-sentinel:26379" \
-	go test -v -covermode=atomic -cover -race -coverprofile=coverage.txt ./...
+	go test -v -covermode=atomic -cover -race -coverprofile=coverage.txt -p 1 ./...
 
 
 

--- a/README.md
+++ b/README.md
@@ -24,14 +24,6 @@ go build .
 For pre-built binaries please take a look at [the releases](https://github.com/oliver006/redis_exporter/releases).
 
 
-### Upgrading from 0.x to 1.x
-
-[PR #256](https://github.com/oliver006/redis_exporter/pull/256) introduced breaking changes which were released as version v1.0.0.
-
-If you only scrape one Redis instance and use command line flags `--redis.address`
-and `--redis.password` then you're most probably not affected.
-Otherwise, please see [PR #256](https://github.com/oliver006/redis_exporter/pull/256) and [this README](https://github.com/oliver006/redis_exporter#prometheus-configuration-to-scrape-multiple-redis-hosts) for more information.
-
 ### Basic Prometheus Configuration
 
 Add a block to the `scrape_configs` of your prometheus.yml config file:
@@ -236,8 +228,19 @@ Grafana dashboard is available on [grafana.com](https://grafana.com/dashboards/7
 
 If running [Redis Sentinel](https://redis.io/topics/sentinel), it may be desirable to view the metrics of the various cluster members simultaneously. For this reason the dashboard's drop down is of the multi-value type, allowing for the selection of multiple Redis. Please note that there is a  caveat; the single stat panels up top namely `uptime`, `total memory use` and `clients` do not function upon viewing multiple Redis.
 
+
 ## Using the mixin
 There is a set of sample rules, alerts and dashboards available in [redis-mixin](contrib/redis-mixin/)
+
+
+## Upgrading from 0.x to 1.x
+
+[PR #256](https://github.com/oliver006/redis_exporter/pull/256) introduced breaking changes which were released as version v1.0.0.
+
+If you only scrape one Redis instance and use command line flags `--redis.address`
+and `--redis.password` then you're most probably not affected.
+Otherwise, please see [PR #256](https://github.com/oliver006/redis_exporter/pull/256) and [this README](https://github.com/oliver006/redis_exporter#prometheus-configuration-to-scrape-multiple-redis-hosts) for more information.
+
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ include-system-metrics | REDIS_EXPORTER_INCL_SYSTEM_METRICS   | Whether to inclu
 ping-on-connect        | REDIS_EXPORTER_PING_ON_CONNECT       | Whether to ping the redis instance after connecting and record the duration as a metric, defaults to false.
 is-tile38              | REDIS_EXPORTER_IS_TILE38             | Whether to scrape Tile38 specific metrics, defaults to false.
 export-client-list     | REDIS_EXPORTER_EXPORT_CLIENT_LIST    | Whether to scrape Client List specific metrics, defaults to false.
+export-client-port     | REDIS_EXPORTER_EXPORT_CLIENT_PORT    | Whether to include the client's port when exporting the client list. Warning: including the port increases the number of metrics generated and will make your Prometheus server take up more memory
 skip-tls-verification  | REDIS_EXPORTER_SKIP_TLS_VERIFICATION | Whether to to skip TLS verification
 tls-client-key-file    | REDIS_EXPORTER_TLS_CLIENT_KEY_FILE   | Name of the client key file (including full path) if the server requires TLS client authentication
 tls-client-cert-file   | REDIS_EXPORTER_TLS_CLIENT_CERT_FILE  | Name the client cert file (including full path) if the server requires TLS client authentication

--- a/README.md
+++ b/README.md
@@ -169,6 +169,17 @@ Password-protected instances can be accessed by using the URI format including a
 Command line settings take precedence over any configurations provided by the environment variables.
 
 
+### Authenticating with Redis
+
+If your Redis instance requires authentication then there are several ways how you can supply 
+a username (new in Redis 6.x with ACLs) and a password.
+
+You can provide the username and password as part of the address, see [here](https://www.iana.org/assignments/uri-schemes/prov/redis) for the official documentation of the `redis://` scheme.
+This does NOT work when using the `/scrape` endpoint. It is to prevent users from sending Redis passwords in cleartext over the wire.
+
+Alternatively, you can provide the username and/or password using the `--redis.user` and `--redis.password` directly to the redis_exporter.
+
+
 ### Run via Docker
 
 The latest release is automatically published to the [Docker registry](https://hub.docker.com/r/oliver006/redis_exporter/).

--- a/contrib/docker-compose-for-tests.yml
+++ b/contrib/docker-compose-for-tests.yml
@@ -21,7 +21,7 @@ services:
 
   pwd-redis6:
     image: redis:6
-    command: "redis-server --port 6390 --requirepass dummy --user exporter on +INFO +SELECT +SLOWLOG +LATENCY '>exporter-password' --dbfilename dump6-pwd.rdb"
+    command: "redis-server --port 6390 --requirepass dummy --user exporter on +CLIENT +INFO +SELECT +SLOWLOG +LATENCY '>exporter-password' --dbfilename dump6-pwd.rdb"
     ports:
       - 6390
 

--- a/main.go
+++ b/main.go
@@ -69,6 +69,7 @@ func main() {
 		setClientName       = flag.Bool("set-client-name", getEnvBool("REDIS_EXPORTER_SET_CLIENT_NAME", true), "Whether to set client name to redis_exporter")
 		isTile38            = flag.Bool("is-tile38", getEnvBool("REDIS_EXPORTER_IS_TILE38", false), "Whether to scrape Tile38 specific metrics")
 		exportClientList    = flag.Bool("export-client-list", getEnvBool("REDIS_EXPORTER_EXPORT_CLIENT_LIST", false), "Whether to scrape Client List specific metrics")
+		exportClientPort    = flag.Bool("export-client-port", getEnvBool("REDIS_EXPORTER_EXPORT_CLIENT_PORT", false), "Whether to include the client's port when exporting the client list. Warning: including the port increases the number of metrics generated and will make your Prometheus server take up more memory")
 		showVersion         = flag.Bool("version", false, "Show version information and exit")
 		redisMetricsOnly    = flag.Bool("redis-only-metrics", getEnvBool("REDIS_EXPORTER_REDIS_ONLY_METRICS", false), "Whether to also export go runtime metrics")
 		pingOnConnect       = flag.Bool("ping-on-connect", getEnvBool("REDIS_EXPORTER_PING_ON_CONNECT", false), "Whether to ping the redis instance after connecting")
@@ -142,28 +143,29 @@ func main() {
 	exp, err := exporter.NewRedisExporter(
 		*redisAddr,
 		exporter.Options{
-			User:                *redisUser,
-			Password:            *redisPwd,
-			Namespace:           *namespace,
-			ConfigCommandName:   *configCommand,
-			CheckKeys:           *checkKeys,
-			CheckSingleKeys:     *checkSingleKeys,
-			CheckStreams:        *checkStreams,
-			CheckSingleStreams:  *checkSingleStreams,
-			CountKeys:           *countKeys,
-			LuaScript:           ls,
-			InclSystemMetrics:   *inclSystemMetrics,
-			SetClientName:       *setClientName,
-			IsTile38:            *isTile38,
-			ExportClientList:    *exportClientList,
-			SkipTLSVerification: *skipTLSVerification,
-			ClientCertificates:  tlsClientCertificates,
-			CaCertificates:      tlsCaCertificates,
-			ConnectionTimeouts:  to,
-			MetricsPath:         *metricPath,
-			RedisMetricsOnly:    *redisMetricsOnly,
-			PingOnConnect:       *pingOnConnect,
-			Registry:            registry,
+			User:                  *redisUser,
+			Password:              *redisPwd,
+			Namespace:             *namespace,
+			ConfigCommandName:     *configCommand,
+			CheckKeys:             *checkKeys,
+			CheckSingleKeys:       *checkSingleKeys,
+			CheckStreams:          *checkStreams,
+			CheckSingleStreams:    *checkSingleStreams,
+			CountKeys:             *countKeys,
+			LuaScript:             ls,
+			InclSystemMetrics:     *inclSystemMetrics,
+			SetClientName:         *setClientName,
+			IsTile38:              *isTile38,
+			ExportClientList:      *exportClientList,
+			ExportClientsInclPort: *exportClientPort,
+			SkipTLSVerification:   *skipTLSVerification,
+			ClientCertificates:    tlsClientCertificates,
+			CaCertificates:        tlsCaCertificates,
+			ConnectionTimeouts:    to,
+			MetricsPath:           *metricPath,
+			RedisMetricsOnly:      *redisMetricsOnly,
+			PingOnConnect:         *pingOnConnect,
+			Registry:              registry,
 			BuildInfo: exporter.BuildInfo{
 				Version:   BuildVersion,
 				CommitSha: BuildCommitSha,


### PR DESCRIPTION
 when exporting the list of all clients, it greatly increases the label cardinality

plus a few other, minor things.