### PR TITLE
add redis endpoint to connect error message

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -1592,7 +1592,7 @@ func (e *Exporter) scrapeRedisHost(ch chan<- prometheus.Metric) error {
 	e.registerConstMetricGauge(ch, "exporter_last_scrape_connect_time_seconds", connectTookSeconds)
 
 	if err != nil {
-		log.Errorf("Couldn't connect to redis instance")
+		log.Errorf("Couldn't connect to redis instance %s", e.redisAddr)
 		log.Debugf("connectToRedis( %s ) err: %s", e.redisAddr, err)
 		return err
 	}


### PR DESCRIPTION
by default logger does not run in debug mode.
showing the redis endpoint in the exception message at info level and above is helpful.
the connection failure reasons are pretty standard so without the stack trace the info logs can identify connect failures and frequency which can be tracked down at the target level.

Signed-off-by: S.Cavallo <smcavallo@hotmail.com>