### PR TITLE
Default to 0 when using check-single-keys

### DIFF
--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -227,8 +227,8 @@ func TestKeysReset(t *testing.T) {
 	deleteKeysFromDB(t, os.Getenv("TEST_REDIS_URI"))
 
 	body = downloadURL(t, ts.URL+"/metrics")
-	if strings.Contains(body, keys[0]) {
-		t.Errorf("Metric is present in metrics list %q\n%s", keys[0], body)
+	if !strings.Contains(body, keys[0]) {
+		t.Errorf("Key %q (from check-single-keys) should be available in metrics with default value 0\n%s", keys[0], body)
 	}
 }
 


### PR DESCRIPTION
As discussed in #472 and #479, keys passed via check-single-keys are known in advance, so we can default to 0 if those keys are missing (as [suggested by Prometheus](https://prometheus.io/docs/practices/instrumentation/#avoid-missing-metrics)).

This PR does not add defaults for check-keys (as discussed in #479, this would add undesired additional overhead to redis_exporter).