### PR TITLE
Run Docker image as non-root

### DIFF
--- a/docker/Dockerfile.amd64
+++ b/docker/Dockerfile.amd64
@@ -39,6 +39,7 @@ FROM alpine as alpine
 COPY --from=builder /redis_exporter /redis_exporter
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 
+# Run as non-root user for secure environments
 USER 59000:59000
 
 EXPOSE     9121

--- a/docker/Dockerfile.amd64
+++ b/docker/Dockerfile.amd64
@@ -39,5 +39,7 @@ FROM alpine as alpine
 COPY --from=builder /redis_exporter /redis_exporter
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 
+USER 59000:59000
+
 EXPOSE     9121
 ENTRYPOINT [ "/redis_exporter" ]

--- a/docker/Dockerfile.arm
+++ b/docker/Dockerfile.arm
@@ -25,5 +25,8 @@ FROM arm32v6/alpine:3.6 as alpine-arm
 COPY --from=builder /redis_exporter /redis_exporter
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 
+# Run as non-root user for secure environments
+USER 59000:59000
+
 EXPOSE     9121
 ENTRYPOINT [ "/redis_exporter" ]

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -25,6 +25,9 @@ FROM arm64v8/alpine:3.6 as alpine-arm64
 COPY --from=builder /redis_exporter /redis_exporter
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 
+# Run as non-root user for secure environments
+USER 59000:59000
+
 EXPOSE     9121
 ENTRYPOINT [ "/redis_exporter" ]
 


### PR DESCRIPTION
I'v struggled with some issue to get the exporter running by the Helm chart. Pod Security Policy was created but enforced AppArmor profile will prefent the POD start:

```
Status:         Pending
Reason:         AppArmor
Message:        Cannot enforce AppArmor: AppArmor is not enabled on the host
```

The default PSP on my cluster doesn't allow to run root images. Normaly the is a USER defintion in the Dockerfile which is here only in the builder, but not the finally image. Added the USER definition there and got the exporter running.
