### PR TITLE
Copy /etc/nsswitch.conf to scratch docker image

### DIFF
--- a/docker/Dockerfile.amd64
+++ b/docker/Dockerfile.amd64
@@ -23,6 +23,7 @@ FROM scratch as scratch
 
 COPY --from=builder /redis_exporter /redis_exporter
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+COPY --from=builder /etc/nsswitch.conf /etc/nsswitch.conf
 
 # Run as non-root user for secure environments
 USER 59000:59000


### PR DESCRIPTION
When golang resolves `localhost` on a system without a `/etc/nsswitch.conf` present it sends a request to the DNS server instead of using /etc/hosts to directly resolve it to `127.0.0.1`.

In our kubernetes cluster, we used the scratch image as a sidecar to redis, with the address `redis://localhost:6379`.
As the scratch container did not have a `/etc/nsswitch.conf` this generated a lot of DNS queries to localhost.

With this PR, the scratch image copies the /etc/nsswitch.conf file from the builder image. This setup should correctly resolve using the /etc/hosts file first, before doing a DNS query.