### PR TITLE
bug on redis_sentinel v3.0.7

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -528,7 +528,7 @@ func (e *Exporter) scrapeRedisHost(ch chan<- prometheus.Metric) error {
 	}
 
 	infoAll, err := redis.String(doRedisCmd(c, "INFO", "ALL"))
-	if err != nil {
+	if err != nil || infoAll == "" {
 		log.Debugf("Redis INFO ALL err: %s", err)
 		infoAll, err = redis.String(doRedisCmd(c, "INFO"))
 		if err != nil {


### PR DESCRIPTION
in redis_sentinel version 3.0.7
redis_exporter cannot grab information on sentinel nodes
The debug mode shows that there is no info all command on sentinel of version 3.0.7 and no errors are reported.
So the infoall, err part of the code has no output
Modify the code judgment condition to make it use info conditional branch

redis_sentinel 版本3.0.7
redis_exporter不能在sentinel节点抓取信息
debug模式显示在3.0.7版本的sentinel上没有 info all命令并且无任何报错
所以代码中infoall,err部分无输出  
修改代码判断条件，使其能使用info条件分支