### PR TITLE
Add condition to check if key is of type string before running GET to increase performance

### DIFF
--- a/exporter/keys.go
+++ b/exporter/keys.go
@@ -33,6 +33,8 @@ func getKeyInfo(c redis.Conn, key string) (info keyInfo, err error) {
 	case "none":
 		return info, errKeyTypeNotFound
 	case "string":
+        // Use PFCOUNT first because STRLEN on HyperLogLog strings returns the wrong length
+        // while PFCOUNT only works on HLL strings and returns an error on regular strings.
 		if size, err := redis.Int64(doRedisCmd(c, "PFCOUNT", key)); err == nil {
 			// hyperloglog
 			info.size = float64(size)

--- a/exporter/keys.go
+++ b/exporter/keys.go
@@ -107,10 +107,13 @@ func (e *Exporter) extractCheckKeyMetrics(ch chan<- prometheus.Metric, c redis.C
 		case nil:
 			e.registerConstMetricGauge(ch, "key_size", info.size, dbLabel, k.key)
 
-			// Only record value metric if value is float-y
-			if val, err := redis.Float64(doRedisCmd(c, "GET", k.key)); err == nil {
-				e.registerConstMetricGauge(ch, "key_value", val, dbLabel, k.key)
-			}
+            // Only run on single value strings
+            if info.keyType == "string" {
+			    // Only record value metric if value is float-y
+			    if val, err := redis.Float64(doRedisCmd(c, "GET", k.key)); err == nil {
+			    	e.registerConstMetricGauge(ch, "key_value", val, dbLabel, k.key)
+			    }
+            }
 		default:
 			log.Error(err)
 		}


### PR DESCRIPTION
This adds a condition so that GET is only ran on types of keys that it works on - strings.

Before it was ran on every key and you could see errors with debug mode:
running command: GET [my-key]
WRONGTYPE Operation against a key holding the wrong kind of value

This also reduces the number commands ran on Redis from about 4 to 3 per key and should improve performance (unless all of your keys are strings).


I also thought of switching places of PFCOUNT and STRLEN which are ran on string types on the premise that regular strings are more common than HyperLogLog ones and STRLEN being the first conditional could slightly improve performance.

The problem is that STRLEN also works on HLL strings but returns the wrong (or at least not the one we want) value so I left it as is and added a comment for the reasoning behind the order.