### PR TITLE
pin golangci-lint docker image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -139,7 +139,7 @@ steps:
       - start
 
   - name: lint
-    image: golangci/golangci-lint:latest-alpine
+    image: golangci/golangci-lint@sha256:39e13a431c69fca37f88ab4b2340655eef7d7d18373df10d5e737f0b77866747
     pull: always
     commands:
       - apk add --update make


### PR DESCRIPTION
Fails due to updtes to golangci-lint
https://cloud.drone.io/oliver006/redis_exporter/1192

This pins it to an older, working version. Will have to address the underlying issue at some later point.