### PR TITLE
Use $__rate_interval for rate queries in monitoring mixin

### DIFF
--- a/contrib/redis-mixin/dashboards/redis-overview.json
+++ b/contrib/redis-mixin/dashboards/redis-overview.json
@@ -89,7 +89,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(irate(redis_commands_total{instance=~\"$instance\"} [1m])) by (cmd)",
+          "expr": "avg(irate(redis_commands_total{instance=~\"$instance\"} [$__rate_interval])) by (cmd)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -196,7 +196,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(irate(redis_commands_duration_seconds_total{instance=~\"$instance\"}[1m])) by (cmd)\n  /\navg(irate(redis_commands_total{instance=~\"$instance\"}[1m])) by (cmd)\n",
+          "expr": "avg(irate(redis_commands_duration_seconds_total{instance=~\"$instance\"}[$__rate_interval])) by (cmd)\n  /\navg(irate(redis_commands_total{instance=~\"$instance\"}[$__rate_interval])) by (cmd)\n",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -313,7 +313,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(irate(redis_keyspace_hits_total{instance=~\"$instance\"}[1m]) / (irate(redis_keyspace_misses_total{instance=~\"$instance\"}[1m]) + irate(redis_keyspace_hits_total{instance=~\"$instance\"}[1m]))) by (instance)",
+          "expr": "avg(irate(redis_keyspace_hits_total{instance=~\"$instance\"}[$__rate_interval]) / (irate(redis_keyspace_misses_total{instance=~\"$instance\"}[$__rate_interval]) + irate(redis_keyspace_hits_total{instance=~\"$instance\"}[$__rate_interval]))) by (instance)",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -696,7 +696,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(redis_evicted_keys_total{instance=~\"$instance\"}[1m])",
+          "expr": "irate(redis_evicted_keys_total{instance=~\"$instance\"}[$__rate_interval])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,


### PR DESCRIPTION
This PR changes to using [$__rate_interval](https://grafana.com/blog/2020/09/28/new-in-grafana-7.2-__rate_interval-for-prometheus-rate-queries-that-just-work/) for promql queries containing a `rate` function call.

The hardcoded default of `1m` only works when the tsdb has data with a scrape interval of 15s or less. Some users may extend this to 30s or 60s in an effort to reduce time series data storage costs, which would render these queries ineffective.

A second commit on this PR also reduces the default timerange from 12h to 30m. This should help improve responsiveness of the first load, and reduce strain on the tsdb when the dashboard is used regularly.