### PR TITLE
Datasource template variable should be labelled 'Data Source'

### DIFF
--- a/contrib/redis-mixin/dashboards/redis-overview.json
+++ b/contrib/redis-mixin/dashboards/redis-overview.json
@@ -1332,7 +1332,7 @@
         },
         "hide": 0,
         "includeAll": false,
-        "label": null,
+        "label": "Data Source",
         "multi": false,
         "name": "datasource",
         "options": [],


### PR DESCRIPTION
We're building a dashboard linter and this is one of the things that came up. Super minor nit, sorry about that.

Signed-off-by: Tom Wilkie <tom@grafana.com>