### PR TITLE
Build properly with ldflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,3 +80,6 @@ build-binaries:
 	gox -os="linux freebsd netbsd"                        -arch="arm"       -verbose -rebuild -ldflags $(GO_LDFLAGS) -output ".build/redis_exporter-${DRONE_TAG}.{{.OS}}-{{.Arch}}/{{.Dir}}" && \
 	gox -os="linux" -arch="arm64 mips64 mips64le ppc64 ppc64le s390x"       -verbose -rebuild -ldflags $(GO_LDFLAGS) -output ".build/redis_exporter-${DRONE_TAG}.{{.OS}}-{{.Arch}}/{{.Dir}}" && \
 	echo "done"
+
+build:
+	go build -ldflags ${GO_LDFLAGS} -o redis_exporter .

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Supports Redis 2.x, 3.x, 4.x, 5.x, and 6.x
 ```sh
 git clone https://github.com/oliver006/redis_exporter.git
 cd redis_exporter
-go build .
+make build
 ./redis_exporter --version
 ```
 


### PR DESCRIPTION
Current build process does not add all ldflags as it should. I extended Makefile and updated README.md to address this and fix issue https://github.com/oliver006/redis_exporter/issues/601 