### PR TITLE
Allow the ability to customize redis exporter selector

### DIFF
--- a/contrib/redis-mixin/alerts/redis.libsonnet
+++ b/contrib/redis-mixin/alerts/redis.libsonnet
@@ -6,7 +6,7 @@
         rules: [
           {
             alert: 'RedisDown',
-            expr: 'redis_up == 0',
+            expr: 'redis_up{%(redisExporterSelector)s} == 0' % $._config,
             'for': '5m',
             labels: {
               severity: 'critical',
@@ -18,7 +18,7 @@
           },
           {
             alert: 'RedisOutOfMemory',
-            expr: 'redis_memory_used_bytes / redis_total_system_memory_bytes * 100 > 90',
+            expr: 'redis_memory_used_bytes{%(redisExporterSelector)s} / redis_total_system_memory_bytes{%(redisExporterSelector)s} * 100 > 90' % $._config,
             'for': '5m',
             labels: {
               severity: 'warning',
@@ -30,7 +30,7 @@
           },
           {
             alert: 'RedisTooManyConnections',
-            expr: 'redis_connected_clients > %(redisConnectionsThreshold)s' % $._config,
+            expr: 'redis_connected_clients{%(redisExporterSelector)s} > %(redisConnectionsThreshold)s' % $._config,
             'for': '5m',
             labels: {
               severity: 'warning',

--- a/contrib/redis-mixin/config.libsonnet
+++ b/contrib/redis-mixin/config.libsonnet
@@ -1,5 +1,6 @@
 {
   _config+:: {
     redisConnectionsThreshold: '100',
+    redisExporterSelector: 'job="redis"',
   },
 }

--- a/contrib/redis-mixin/rules/redis.libsonnet
+++ b/contrib/redis-mixin/rules/redis.libsonnet
@@ -6,7 +6,7 @@
         rules: [
           {
             record: 'redis_memory_fragmentation_ratio',
-            expr: 'redis_memory_used_rss_bytes / redis_memory_used_bytes',
+            expr: 'redis_memory_used_rss_bytes{%(redisExporterSelector)s} / redis_memory_used_bytes{%(redisExporterSelector)s}' % $._config,
           },
         ],
       },


### PR DESCRIPTION
Most mixins allow to customize selectors as such as seen in the Customising the mixin section in
https://monitoring.mixins.dev/