### PR TITLE
Add redacted addr to scrapeRedisHost error message (#638)

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -3,6 +3,7 @@ package exporter
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"runtime"
 	"strconv"
 	"strings"
@@ -528,7 +529,14 @@ func (e *Exporter) scrapeRedisHost(ch chan<- prometheus.Metric) error {
 	e.registerConstMetricGauge(ch, "exporter_last_scrape_connect_time_seconds", connectTookSeconds)
 
 	if err != nil {
-		log.Errorf("Couldn't connect to redis instance")
+		var redactedAddr string
+		if redisURL, err2 := url.Parse(e.redisAddr); err2 != nil {
+			log.Debugf("url.Parse( %s ) err: %s", e.redisAddr, err2)
+			redactedAddr = "<redacted>"
+		} else {
+			redactedAddr = redisURL.Redacted()
+		}
+		log.Errorf("Couldn't connect to redis instance (%s)", redactedAddr)
 		log.Debugf("connectToRedis( %s ) err: %s", e.redisAddr, err)
 		return err
 	}


### PR DESCRIPTION
When `scrapeRedisHost` fails to connect to a Redis instance, the code now tries to redact the password of the Redis address (URL).  If it can parse and redact it, it will print the address in the error message.   Otherwise, we note that `-debug` is needed to see the address.   It does not log any URL parsing errors, just in case that may leak any info.

Testing:
```
> ./redis_exporter  -redis.addr "redis://user:peace@foobar.com:9999"
INFO[0000] Redis Metrics Exporter <<< filled in by build >>>    build date: <<< filled in by build >>>    sha1: <<< filled in by build >>>    Go: go1.18.1    GOOS: darwin    GOARCH: arm64 
INFO[0000] Providing metrics at :9121/metrics           
ERRO[0018] Couldn't connect to redis instance (redis://user:xxxxx@foobar.com:9999)
```