### PR TITLE
Add /scrape-all endpoint

### DIFF
--- a/exporter/http.go
+++ b/exporter/http.go
@@ -88,3 +88,36 @@ func (e *Exporter) scrapeHandler(w http.ResponseWriter, r *http.Request) {
 		registry, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError},
 	).ServeHTTP(w, r)
 }
+
+func (e *Exporter) scrapeAllHandler(w http.ResponseWriter, r *http.Request) {
+	registry := prometheus.NewRegistry()
+	e.options.Registry = registry
+	e.options.ScrapeMultipleUris = true
+	for target := range e.options.PasswordMap {
+		if !strings.Contains(target, "://") {
+			target = "redis://" + target
+		}
+
+		u, err := url.Parse(target)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Invalid URI, parse err: %ck ", err), http.StatusBadRequest)
+			e.targetScrapeRequestErrors.Inc()
+			return
+		}
+
+		// get rid of username/password if present in the uri itself
+		u.User = nil
+		target = u.String()
+
+		_, err = NewRedisExporter(target, e.options)
+		if err != nil {
+			http.Error(w, "NewRedisExporter() err: err", http.StatusBadRequest)
+			e.targetScrapeRequestErrors.Inc()
+			return
+		}
+	}
+
+	promhttp.HandlerFor(
+		registry, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError},
+	).ServeHTTP(w, r)
+}

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -15,8 +15,8 @@ func sanitizeMetricName(n string) string {
 	return metricNameRE.ReplaceAllString(n, "_")
 }
 
-func newMetricDescr(namespace string, metricName string, docString string, labels []string) *prometheus.Desc {
-	return prometheus.NewDesc(prometheus.BuildFQName(namespace, "", metricName), docString, labels, nil)
+func newMetricDescr(namespace string, metricName string, docString string, labels []string, constLabels prometheus.Labels) *prometheus.Desc {
+	return prometheus.NewDesc(prometheus.BuildFQName(namespace, "", metricName), docString, labels, constLabels)
 }
 
 func (e *Exporter) includeMetric(s string) bool {
@@ -82,7 +82,7 @@ func (e *Exporter) registerConstMetricGauge(ch chan<- prometheus.Metric, metric 
 func (e *Exporter) registerConstMetric(ch chan<- prometheus.Metric, metric string, val float64, valType prometheus.ValueType, labelValues ...string) {
 	descr := e.metricDescriptions[metric]
 	if descr == nil {
-		descr = newMetricDescr(e.options.Namespace, metric, metric+" metric", labelValues)
+		descr = newMetricDescr(e.options.Namespace, metric, metric+" metric", labelValues, e.constLabels)
 	}
 
 	if m, err := prometheus.NewConstMetric(descr, valType, val, labelValues...); err == nil {

--- a/exporter/pwd_file.go
+++ b/exporter/pwd_file.go
@@ -23,7 +23,7 @@ func LoadPwdFile(passwordFile string) (map[string]string, error) {
 		return nil, err
 	}
 
-	log.Errorf("Loaded %d entries from %s", len(res), passwordFile)
+	log.Infof("Loaded %d entries from %s", len(res), passwordFile)
 	for k := range res {
 		log.Debugf("%s", k)
 	}


### PR DESCRIPTION
Hello,

A bit history: in the past redis_exporter was capable to scrape multiple endpoints at once. Later it was removed and a tradeoff has been made by implementing `-redis.password-file` option + putting all the efforts on Prometheus to scrape multiple targets by using /scrape endpoint with `target` query arg.

Here I propose a very minimal PR which basically re-uses the existing `-redis.password-file` and adds a new endpoint /scape-all in order to scrape all redis endpoints listed in the password file:

* minimalistic PR
* no changes to the existing functionality, nothing breaks
* whoever wants to scrape multiple instances at once can do this with the least efforts
* helps in performance as we don't need to add a ton of targets into Prometheus (we run 30 redis dbs per host) 

When you want scrape all defined endpoints, simply do this by going into /scrape-all. Because metrics need to be unique per endpoint we add `addr` label with the actual endpoint url. Optionally, you can add other custom labels via query arg, e.g. the file entry `{"redis://127.0.0.1:36379?db=foobar": "mypassword"}` will produce metrics with labels `{addr="redis://127.0.0.1:36379", db="foobar", ...}`

Thanks!