### PR TITLE
Added latency_percentiles_usec summary (A summary of latency percentile distribution per command)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -23,6 +23,14 @@ services:
     ports:
       - 6379
 
+  - name: redis7
+      image: redis:7
+      pull: if-not-exists
+      commands:
+        - "redis-server --protected-mode no --dbfilename dump7.rdb"
+      ports:
+        - 6384
+
   - name: pwd-redis5
     image: redis:5
     pull: if-not-exists

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ test:
 	TEST_REDIS_URI="redis://redis6:6379" \
 	TEST_REDIS5_URI="redis://redis5:6383" \
 	TEST_REDIS6_URI="redis://redis6:6379" \
+	TEST_REDIS7_URI="redis://redis7:6384" \
 	TEST_REDIS_2_8_URI="redis://redis-2-8:6381" \
 	TEST_KEYDB01_URI="redis://keydb-01:6401" \
 	TEST_KEYDB02_URI="redis://keydb-02:6402" \

--- a/contrib/docker-compose-for-tests.yml
+++ b/contrib/docker-compose-for-tests.yml
@@ -13,6 +13,12 @@ services:
     ports:
       - "6379"
 
+  redis7:
+    image: redis:7.0
+    command: "redis-server --protected-mode no --dbfilename dump7.rdb"
+    ports:
+      - "6384"
+
   pwd-redis5:
     image: redis:5
     command: "redis-server --port 6380 --requirepass redis-password --dbfilename dump5-pwd.rdb"

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -342,6 +342,7 @@ func NewRedisExporter(redisURI string, opts Options) (*Exporter, error) {
 		"commands_failed_calls_total":                  {txt: `Total number of errors prior command execution per command`, lbls: []string{"cmd"}},
 		"commands_rejected_calls_total":                {txt: `Total number of errors within command execution per command`, lbls: []string{"cmd"}},
 		"commands_total":                               {txt: `Total number of calls per command`, lbls: []string{"cmd"}},
+		"latency_percentiles_usec":                     {txt: `A summary of latency percentile distribution per command`, lbls: []string{"cmd"}},
 		"config_key_value":                             {txt: `Config key and value`, lbls: []string{"key", "value"}},
 		"config_value":                                 {txt: `Config key and value as metric`, lbls: []string{"key"}},
 		"connected_clients_details":                    {txt: "Details about connected clients", lbls: connectedClientsLabels},

--- a/exporter/info.go
+++ b/exporter/info.go
@@ -415,7 +415,7 @@ func parseMetricsLatencyStats(fieldKey string, fieldValue string) (cmd string, p
 	for pos, kv := range splitValue {
 		percentile, value, err := extractPercentileVal(kv)
 		if err != nil {
-			errorOut = errors.New(fmt.Sprintf("Invalid splitValue[%d]", pos))
+			errorOut = fmt.Errorf("Invalid splitValue[%d]", pos)
 			return
 		}
 		percentileMap[percentile] = value

--- a/exporter/info.go
+++ b/exporter/info.go
@@ -126,13 +126,7 @@ func (e *Exporter) extractInfoMetrics(ch chan<- prometheus.Metric, info string, 
 
 	// To be able to generate the latency summaries we need the count and sum that we get
 	// from #Commandstats processing and the percentile info that we get from the #Latencystats processing
-	for cmd, latencyMap := range cmdLatencyMap {
-		count, okCount := cmdCount[cmd]
-		sum, okSum := cmdSum[cmd]
-		if okCount && okSum {
-			e.registerConstSummary(ch, "latency_percentiles_usec", []string{"cmd"}, count, sum, latencyMap, cmd)
-		}
-	}
+	e.generateCommandLatencySummaries(ch, cmdLatencyMap, cmdCount, cmdSum)
 
 	for dbIndex := 0; dbIndex < dbCount; dbIndex++ {
 		dbName := "db" + strconv.Itoa(dbIndex)
@@ -157,6 +151,16 @@ func (e *Exporter) extractInfoMetrics(ch chan<- prometheus.Metric, info string, 
 			keyValues["master_host"],
 			keyValues["master_port"],
 			keyValues["slave_read_only"])
+	}
+}
+
+func (e *Exporter) generateCommandLatencySummaries(ch chan<- prometheus.Metric, cmdLatencyMap map[string]map[float64]float64, cmdCount map[string]uint64, cmdSum map[string]float64) {
+	for cmd, latencyMap := range cmdLatencyMap {
+		count, okCount := cmdCount[cmd]
+		sum, okSum := cmdSum[cmd]
+		if okCount && okSum {
+			e.registerConstSummary(ch, "latency_percentiles_usec", []string{"cmd"}, count, sum, latencyMap, cmd)
+		}
 	}
 }
 

--- a/exporter/info_test.go
+++ b/exporter/info_test.go
@@ -88,7 +88,6 @@ func TestParseConnectedSlaveString(t *testing.T) {
 func TestCommandStats(t *testing.T) {
 	defaultAddr := os.Getenv("TEST_REDIS_URI")
 	redisSixTwoAddr := os.Getenv("TEST_REDIS6_URI")
-	redisSevenAddr := os.Getenv("TEST_REDIS7_URI")
 	e := getTestExporterWithAddr(defaultAddr)
 	setupDBKeys(t, defaultAddr)
 

--- a/exporter/info_test.go
+++ b/exporter/info_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http/httptest"
 	"os"
+	"reflect"
 	"regexp"
 	"strings"
 	"testing"
@@ -87,6 +88,7 @@ func TestParseConnectedSlaveString(t *testing.T) {
 func TestCommandStats(t *testing.T) {
 	defaultAddr := os.Getenv("TEST_REDIS_URI")
 	redisSixTwoAddr := os.Getenv("TEST_REDIS6_URI")
+	redisSevenAddr := os.Getenv("TEST_REDIS7_URI")
 	e := getTestExporterWithAddr(defaultAddr)
 	setupDBKeys(t, defaultAddr)
 
@@ -101,6 +103,18 @@ func TestCommandStats(t *testing.T) {
 	want = map[string]bool{"test_commands_duration_seconds_total": false, "test_commands_total": false, "commands_failed_calls_total": false, "commands_rejected_calls_total": false, "errors_total": false}
 	commandStatsCheck(t, e, want)
 	deleteKeysFromDB(t, redisSixTwoAddr)
+}
+
+func TestLatencyStats(t *testing.T) {
+	redisSevenAddr := os.Getenv("TEST_REDIS7_URI")
+
+	// Since Redis v7 we should have extended latency stats (summary of command latencies)
+	e := getTestExporterWithAddr(redisSevenAddr)
+	setupDBKeys(t, redisSevenAddr)
+
+	want := map[string]bool{"redis_latency_percentiles_usec": false}
+	commandStatsCheck(t, e, want)
+	deleteKeysFromDB(t, redisSevenAddr)
 }
 
 func commandStatsCheck(t *testing.T, e *Exporter, want map[string]bool) {
@@ -372,4 +386,69 @@ func TestParseErrorStats(t *testing.T) {
 		})
 	}
 
+}
+
+func Test_parseMetricsLatencyStats(t *testing.T) {
+	type args struct {
+		fieldKey   string
+		fieldValue string
+	}
+	tests := []struct {
+		name              string
+		args              args
+		wantCmd           string
+		wantPercentileMap map[float64]float64
+		wantErr           bool
+	}{
+		{
+			name:              "simple",
+			args:              args{fieldKey: "latency_percentiles_usec_ping", fieldValue: "p50=0.001,p99=1.003,p99.9=3.007"},
+			wantCmd:           "ping",
+			wantPercentileMap: map[float64]float64{50.0: 0.001, 99.0: 1.003, 99.9: 3.007},
+			wantErr:           false,
+		},
+		{
+			name:              "single-percentile",
+			args:              args{fieldKey: "latency_percentiles_usec_ping", fieldValue: "p50=0.001"},
+			wantCmd:           "ping",
+			wantPercentileMap: map[float64]float64{50.0: 0.001},
+			wantErr:           false,
+		},
+		{
+			name:              "empty",
+			args:              args{fieldKey: "latency_percentiles_usec_ping", fieldValue: ""},
+			wantCmd:           "ping",
+			wantPercentileMap: map[float64]float64{0: 0},
+			wantErr:           false,
+		},
+		{
+			name:              "invalid-percentile",
+			args:              args{fieldKey: "latency_percentiles_usec_ping", fieldValue: "p50=a"},
+			wantCmd:           "ping",
+			wantPercentileMap: map[float64]float64{},
+			wantErr:           true,
+		},
+		{
+			name:              "invalid prefix",
+			args:              args{fieldKey: "wrong_prefix_", fieldValue: "p50=0.001,p99=1.003,p99.9=3.007"},
+			wantCmd:           "",
+			wantPercentileMap: map[float64]float64{},
+			wantErr:           true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotCmd, gotPercentileMap, err := parseMetricsLatencyStats(tt.args.fieldKey, tt.args.fieldValue)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("test %s. parseMetricsLatencyStats() error = %v, wantErr %v", tt.name, err, tt.wantErr)
+				return
+			}
+			if gotCmd != tt.wantCmd {
+				t.Errorf("parseMetricsLatencyStats() gotCmd = %v, want %v", gotCmd, tt.wantCmd)
+			}
+			if !reflect.DeepEqual(gotPercentileMap, tt.wantPercentileMap) {
+				t.Errorf("parseMetricsLatencyStats() gotPercentileMap = %v, want %v", gotPercentileMap, tt.wantPercentileMap)
+			}
+		})
+	}
 }

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -89,3 +89,18 @@ func (e *Exporter) registerConstMetric(ch chan<- prometheus.Metric, metric strin
 		ch <- m
 	}
 }
+
+func (e *Exporter) registerConstSummary(ch chan<- prometheus.Metric, metric string, labelValues []string, count uint64, sum float64, latencyMap map[float64]float64, cmd string) {
+	descr := e.metricDescriptions[metric]
+	if descr == nil {
+		descr = newMetricDescr(e.options.Namespace, metric, metric+" metric", labelValues)
+	}
+	// Create a constant summary from values we got from a 3rd party telemetry system.
+	s := prometheus.MustNewConstSummary(
+		descr,
+		count, sum,
+		latencyMap,
+		cmd,
+	)
+	ch <- s
+}


### PR DESCRIPTION
As of Redis 7 ( specifically this PR https://github.com/redis/redis/pull/9462 ) it possible exporting the per-command percentile distribution via the `INFO LATENCYSTATS` subcommand or `INFO ALL`. ( percentile distribution is not mergeable between cluster nodes )

Here's a sample of INFO ALL ( focusing on commandstats and latencystats ):
```
(...)
# Commandstats
cmdstat_rpop:calls=100000,usec=109759,usec_per_call=1.10,rejected_calls=0,failed_calls=0
cmdstat_set:calls=100000,usec=76770,usec_per_call=0.77,rejected_calls=0,failed_calls=0
cmdstat_zadd:calls=100000,usec=146737,usec_per_call=1.47,rejected_calls=0,failed_calls=0
cmdstat_mset:calls=100000,usec=381537,usec_per_call=3.82,rejected_calls=0,failed_calls=0
cmdstat_lpop:calls=100000,usec=130932,usec_per_call=1.31,rejected_calls=0,failed_calls=0
cmdstat_rpush:calls=100000,usec=69972,usec_per_call=0.70,rejected_calls=0,failed_calls=0
cmdstat_get:calls=100000,usec=69280,usec_per_call=0.69,rejected_calls=0,failed_calls=0
cmdstat_zpopmin:calls=100000,usec=49284,usec_per_call=0.49,rejected_calls=0,failed_calls=0
cmdstat_ping:calls=200000,usec=39815,usec_per_call=0.20,rejected_calls=0,failed_calls=0
cmdstat_spop:calls=100000,usec=48228,usec_per_call=0.48,rejected_calls=0,failed_calls=0
cmdstat_incr:calls=100000,usec=62637,usec_per_call=0.63,rejected_calls=0,failed_calls=0
cmdstat_lrange:calls=400000,usec=19436744,usec_per_call=48.59,rejected_calls=0,failed_calls=0
cmdstat_hset:calls=100000,usec=120657,usec_per_call=1.21,rejected_calls=0,failed_calls=0
cmdstat_config|get:calls=2,usec=26,usec_per_call=13.00,rejected_calls=0,failed_calls=0
cmdstat_lpush:calls=200000,usec=229105,usec_per_call=1.15,rejected_calls=0,failed_calls=0
cmdstat_sadd:calls=100000,usec=54369,usec_per_call=0.54,rejected_calls=0,failed_calls=0

# Errorstats

# Latencystats
latency_percentiles_usec_rpop:p50=1.003,p99=3.007,p99.9=10.047
latency_percentiles_usec_set:p50=1.003,p99=2.007,p99.9=3.007
latency_percentiles_usec_zadd:p50=1.003,p99=6.015,p99.9=17.023
latency_percentiles_usec_mset:p50=3.007,p99=8.031,p99.9=19.071
latency_percentiles_usec_lpop:p50=1.003,p99=4.015,p99.9=12.031
latency_percentiles_usec_rpush:p50=1.003,p99=3.007,p99.9=12.031
latency_percentiles_usec_get:p50=1.003,p99=2.007,p99.9=3.007
latency_percentiles_usec_zpopmin:p50=0.001,p99=2.007,p99.9=6.015
latency_percentiles_usec_ping:p50=0.001,p99=1.003,p99.9=2.007
latency_percentiles_usec_spop:p50=0.001,p99=2.007,p99.9=6.015
latency_percentiles_usec_incr:p50=1.003,p99=2.007,p99.9=3.007
latency_percentiles_usec_lrange:p50=53.247,p99=134.143,p99.9=154.623
latency_percentiles_usec_hset:p50=1.003,p99=5.023,p99.9=14.015
latency_percentiles_usec_config|get:p50=5.023,p99=21.119,p99.9=21.119
latency_percentiles_usec_lpush:p50=1.003,p99=5.023,p99.9=19.071
latency_percentiles_usec_sadd:p50=1.003,p99=2.007,p99.9=5.023

```

With the above info we can generate Prometheus compliant summaries ( one per command ).
```
# HELP redis_latency_percentiles_usec A summary of latency percentile distribution per command
# TYPE redis_latency_percentiles_usec summary
redis_latency_percentiles_usec{cmd="client|setname",quantile="50"} 5.023
redis_latency_percentiles_usec{cmd="client|setname",quantile="99"} 5.023
redis_latency_percentiles_usec{cmd="client|setname",quantile="99.9"} 5.023
redis_latency_percentiles_usec_sum{cmd="client|setname"} 5
redis_latency_percentiles_usec_count{cmd="client|setname"} 1
redis_latency_percentiles_usec{cmd="config|get",quantile="50"} 21.119
redis_latency_percentiles_usec{cmd="config|get",quantile="99"} 440.319
redis_latency_percentiles_usec{cmd="config|get",quantile="99.9"} 440.319
redis_latency_percentiles_usec_sum{cmd="config|get"} 465
redis_latency_percentiles_usec_count{cmd="config|get"} 3
redis_latency_percentiles_usec{cmd="get",quantile="50"} 1.003
redis_latency_percentiles_usec{cmd="get",quantile="99"} 2.007
redis_latency_percentiles_usec{cmd="get",quantile="99.9"} 3.007
redis_latency_percentiles_usec_sum{cmd="get"} 69280
redis_latency_percentiles_usec_count{cmd="get"} 100000
redis_latency_percentiles_usec{cmd="hset",quantile="50"} 1.003
redis_latency_percentiles_usec{cmd="hset",quantile="99"} 5.023
redis_latency_percentiles_usec{cmd="hset",quantile="99.9"} 14.015
redis_latency_percentiles_usec_sum{cmd="hset"} 120657
redis_latency_percentiles_usec_count{cmd="hset"} 100000
redis_latency_percentiles_usec{cmd="incr",quantile="50"} 1.003
redis_latency_percentiles_usec{cmd="incr",quantile="99"} 2.007
redis_latency_percentiles_usec{cmd="incr",quantile="99.9"} 3.007
redis_latency_percentiles_usec_sum{cmd="incr"} 62637
redis_latency_percentiles_usec_count{cmd="incr"} 100000
redis_latency_percentiles_usec{cmd="info",quantile="50"} 411.647
redis_latency_percentiles_usec{cmd="info",quantile="99"} 411.647
redis_latency_percentiles_usec{cmd="info",quantile="99.9"} 411.647
redis_latency_percentiles_usec_sum{cmd="info"} 411
redis_latency_percentiles_usec_count{cmd="info"} 1
redis_latency_percentiles_usec{cmd="lpop",quantile="50"} 1.003
redis_latency_percentiles_usec{cmd="lpop",quantile="99"} 4.015
redis_latency_percentiles_usec{cmd="lpop",quantile="99.9"} 12.031
redis_latency_percentiles_usec_sum{cmd="lpop"} 130932
redis_latency_percentiles_usec_count{cmd="lpop"} 100000
redis_latency_percentiles_usec{cmd="lpush",quantile="50"} 1.003
redis_latency_percentiles_usec{cmd="lpush",quantile="99"} 5.023
redis_latency_percentiles_usec{cmd="lpush",quantile="99.9"} 19.071
redis_latency_percentiles_usec_sum{cmd="lpush"} 229105
redis_latency_percentiles_usec_count{cmd="lpush"} 200000
redis_latency_percentiles_usec{cmd="lrange",quantile="50"} 53.247
redis_latency_percentiles_usec{cmd="lrange",quantile="99"} 134.143
redis_latency_percentiles_usec{cmd="lrange",quantile="99.9"} 154.623
redis_latency_percentiles_usec_sum{cmd="lrange"} 1.9436744e+07
redis_latency_percentiles_usec_count{cmd="lrange"} 400000
redis_latency_percentiles_usec{cmd="mset",quantile="50"} 3.007
redis_latency_percentiles_usec{cmd="mset",quantile="99"} 8.031
redis_latency_percentiles_usec{cmd="mset",quantile="99.9"} 19.071
redis_latency_percentiles_usec_sum{cmd="mset"} 381537
redis_latency_percentiles_usec_count{cmd="mset"} 100000
redis_latency_percentiles_usec{cmd="ping",quantile="50"} 0.001
redis_latency_percentiles_usec{cmd="ping",quantile="99"} 1.003
redis_latency_percentiles_usec{cmd="ping",quantile="99.9"} 2.007
redis_latency_percentiles_usec_sum{cmd="ping"} 39815
redis_latency_percentiles_usec_count{cmd="ping"} 200000
redis_latency_percentiles_usec{cmd="rpop",quantile="50"} 1.003
redis_latency_percentiles_usec{cmd="rpop",quantile="99"} 3.007
redis_latency_percentiles_usec{cmd="rpop",quantile="99.9"} 10.047
redis_latency_percentiles_usec_sum{cmd="rpop"} 109759
redis_latency_percentiles_usec_count{cmd="rpop"} 100000
redis_latency_percentiles_usec{cmd="rpush",quantile="50"} 1.003
redis_latency_percentiles_usec{cmd="rpush",quantile="99"} 3.007
redis_latency_percentiles_usec{cmd="rpush",quantile="99.9"} 12.031
redis_latency_percentiles_usec_sum{cmd="rpush"} 69972
redis_latency_percentiles_usec_count{cmd="rpush"} 100000
redis_latency_percentiles_usec{cmd="sadd",quantile="50"} 1.003
redis_latency_percentiles_usec{cmd="sadd",quantile="99"} 2.007
redis_latency_percentiles_usec{cmd="sadd",quantile="99.9"} 5.023
redis_latency_percentiles_usec_sum{cmd="sadd"} 54369
redis_latency_percentiles_usec_count{cmd="sadd"} 100000
redis_latency_percentiles_usec{cmd="set",quantile="50"} 1.003
redis_latency_percentiles_usec{cmd="set",quantile="99"} 2.007
redis_latency_percentiles_usec{cmd="set",quantile="99.9"} 3.007
redis_latency_percentiles_usec_sum{cmd="set"} 76770
redis_latency_percentiles_usec_count{cmd="set"} 100000
redis_latency_percentiles_usec{cmd="spop",quantile="50"} 0.001
redis_latency_percentiles_usec{cmd="spop",quantile="99"} 2.007
redis_latency_percentiles_usec{cmd="spop",quantile="99.9"} 6.015
redis_latency_percentiles_usec_sum{cmd="spop"} 48228
redis_latency_percentiles_usec_count{cmd="spop"} 100000
redis_latency_percentiles_usec{cmd="zadd",quantile="50"} 1.003
redis_latency_percentiles_usec{cmd="zadd",quantile="99"} 6.015
redis_latency_percentiles_usec{cmd="zadd",quantile="99.9"} 17.023
redis_latency_percentiles_usec_sum{cmd="zadd"} 146737
redis_latency_percentiles_usec_count{cmd="zadd"} 100000
redis_latency_percentiles_usec{cmd="zpopmin",quantile="50"} 0.001
redis_latency_percentiles_usec{cmd="zpopmin",quantile="99"} 2.007
redis_latency_percentiles_usec{cmd="zpopmin",quantile="99.9"} 6.015
redis_latency_percentiles_usec_sum{cmd="zpopmin"} 49284
redis_latency_percentiles_usec_count{cmd="zpopmin"} 100000
```

## Note: controlling the exported percentiles on Redis 
Notice that the exported percentiles on redis can be configured and that by default Redis exports the p50, p99 and p999. The logic behind this PR is agnostic to the exported percentiles. 
As an example let's extend the exported percentiles in Redis to:
```
$ redis-cli 
127.0.0.1:6379> CONFIG SET latency-tracking-info-percentiles "0.0 50.0 75.0 95.0 99.0 100.0"
OK
```

The resulting exported summaries would be:
```
# HELP redis_latency_percentiles_usec A summary of latency percentile distribution per command
# TYPE redis_latency_percentiles_usec summary
redis_latency_percentiles_usec{cmd="client|setname",quantile="0"} 0
redis_latency_percentiles_usec{cmd="client|setname",quantile="50"} 3.007
redis_latency_percentiles_usec{cmd="client|setname",quantile="75"} 5.023
redis_latency_percentiles_usec{cmd="client|setname",quantile="95"} 5.023
redis_latency_percentiles_usec{cmd="client|setname",quantile="99"} 5.023
redis_latency_percentiles_usec{cmd="client|setname",quantile="100"} 5.023
redis_latency_percentiles_usec_sum{cmd="client|setname"} 8
redis_latency_percentiles_usec_count{cmd="client|setname"} 2
redis_latency_percentiles_usec{cmd="command",quantile="0"} 0
redis_latency_percentiles_usec{cmd="command",quantile="50"} 1654.783
redis_latency_percentiles_usec{cmd="command",quantile="75"} 1654.783
redis_latency_percentiles_usec{cmd="command",quantile="95"} 1654.783
redis_latency_percentiles_usec{cmd="command",quantile="99"} 1654.783
redis_latency_percentiles_usec{cmd="command",quantile="100"} 1654.783
redis_latency_percentiles_usec_sum{cmd="command"} 1651
redis_latency_percentiles_usec_count{cmd="command"} 1
redis_latency_percentiles_usec{cmd="config|get",quantile="0"} 0
redis_latency_percentiles_usec{cmd="config|get",quantile="50"} 21.119
redis_latency_percentiles_usec{cmd="config|get",quantile="75"} 360.447
redis_latency_percentiles_usec{cmd="config|get",quantile="95"} 440.319
redis_latency_percentiles_usec{cmd="config|get",quantile="99"} 440.319
redis_latency_percentiles_usec{cmd="config|get",quantile="100"} 440.319
redis_latency_percentiles_usec_sum{cmd="config|get"} 824
redis_latency_percentiles_usec_count{cmd="config|get"} 4
redis_latency_percentiles_usec{cmd="config|set",quantile="0"} 0
redis_latency_percentiles_usec{cmd="config|set",quantile="50"} 30.079
redis_latency_percentiles_usec{cmd="config|set",quantile="75"} 30.079
redis_latency_percentiles_usec{cmd="config|set",quantile="95"} 30.079
redis_latency_percentiles_usec{cmd="config|set",quantile="99"} 30.079
redis_latency_percentiles_usec{cmd="config|set",quantile="100"} 30.079
redis_latency_percentiles_usec_sum{cmd="config|set"} 30
redis_latency_percentiles_usec_count{cmd="config|set"} 1
redis_latency_percentiles_usec{cmd="get",quantile="0"} 0
redis_latency_percentiles_usec{cmd="get",quantile="50"} 1.003
redis_latency_percentiles_usec{cmd="get",quantile="75"} 1.003
redis_latency_percentiles_usec{cmd="get",quantile="95"} 1.003
redis_latency_percentiles_usec{cmd="get",quantile="99"} 2.007
redis_latency_percentiles_usec{cmd="get",quantile="100"} 8585.215
redis_latency_percentiles_usec_sum{cmd="get"} 69280
redis_latency_percentiles_usec_count{cmd="get"} 100000
redis_latency_percentiles_usec{cmd="hset",quantile="0"} 0
redis_latency_percentiles_usec{cmd="hset",quantile="50"} 1.003
redis_latency_percentiles_usec{cmd="hset",quantile="75"} 1.003
redis_latency_percentiles_usec{cmd="hset",quantile="95"} 3.007
redis_latency_percentiles_usec{cmd="hset",quantile="99"} 5.023
redis_latency_percentiles_usec{cmd="hset",quantile="100"} 1228.799
redis_latency_percentiles_usec_sum{cmd="hset"} 120657
redis_latency_percentiles_usec_count{cmd="hset"} 100000
redis_latency_percentiles_usec{cmd="incr",quantile="0"} 0
redis_latency_percentiles_usec{cmd="incr",quantile="50"} 1.003
redis_latency_percentiles_usec{cmd="incr",quantile="75"} 1.003
redis_latency_percentiles_usec{cmd="incr",quantile="95"} 1.003
redis_latency_percentiles_usec{cmd="incr",quantile="99"} 2.007
redis_latency_percentiles_usec{cmd="incr",quantile="100"} 74.239
redis_latency_percentiles_usec_sum{cmd="incr"} 62637
redis_latency_percentiles_usec_count{cmd="incr"} 100000
redis_latency_percentiles_usec{cmd="info",quantile="0"} 0
redis_latency_percentiles_usec{cmd="info",quantile="50"} 411.647
redis_latency_percentiles_usec{cmd="info",quantile="75"} 999.423
redis_latency_percentiles_usec{cmd="info",quantile="95"} 999.423
redis_latency_percentiles_usec{cmd="info",quantile="99"} 999.423
redis_latency_percentiles_usec{cmd="info",quantile="100"} 999.423
redis_latency_percentiles_usec_sum{cmd="info"} 1410
redis_latency_percentiles_usec_count{cmd="info"} 2
redis_latency_percentiles_usec{cmd="latency|latest",quantile="0"} 0
redis_latency_percentiles_usec{cmd="latency|latest",quantile="50"} 4.015
redis_latency_percentiles_usec{cmd="latency|latest",quantile="75"} 4.015
redis_latency_percentiles_usec{cmd="latency|latest",quantile="95"} 4.015
redis_latency_percentiles_usec{cmd="latency|latest",quantile="99"} 4.015
redis_latency_percentiles_usec{cmd="latency|latest",quantile="100"} 4.015
redis_latency_percentiles_usec_sum{cmd="latency|latest"} 4
redis_latency_percentiles_usec_count{cmd="latency|latest"} 1
redis_latency_percentiles_usec{cmd="lpop",quantile="0"} 0
redis_latency_percentiles_usec{cmd="lpop",quantile="50"} 1.003
redis_latency_percentiles_usec{cmd="lpop",quantile="75"} 2.007
redis_latency_percentiles_usec{cmd="lpop",quantile="95"} 3.007
redis_latency_percentiles_usec{cmd="lpop",quantile="99"} 4.015
redis_latency_percentiles_usec{cmd="lpop",quantile="100"} 54.015
redis_latency_percentiles_usec_sum{cmd="lpop"} 130932
redis_latency_percentiles_usec_count{cmd="lpop"} 100000
redis_latency_percentiles_usec{cmd="lpush",quantile="0"} 0
redis_latency_percentiles_usec{cmd="lpush",quantile="50"} 1.003
redis_latency_percentiles_usec{cmd="lpush",quantile="75"} 1.003
redis_latency_percentiles_usec{cmd="lpush",quantile="95"} 2.007
redis_latency_percentiles_usec{cmd="lpush",quantile="99"} 5.023
redis_latency_percentiles_usec{cmd="lpush",quantile="100"} 125.439
redis_latency_percentiles_usec_sum{cmd="lpush"} 229105
redis_latency_percentiles_usec_count{cmd="lpush"} 200000
redis_latency_percentiles_usec{cmd="lrange",quantile="0"} 0
redis_latency_percentiles_usec{cmd="lrange",quantile="50"} 53.247
redis_latency_percentiles_usec{cmd="lrange",quantile="75"} 64.255
redis_latency_percentiles_usec{cmd="lrange",quantile="95"} 112.127
redis_latency_percentiles_usec{cmd="lrange",quantile="99"} 134.143
redis_latency_percentiles_usec{cmd="lrange",quantile="100"} 2736.127
redis_latency_percentiles_usec_sum{cmd="lrange"} 1.9436744e+07
redis_latency_percentiles_usec_count{cmd="lrange"} 400000
redis_latency_percentiles_usec{cmd="mset",quantile="0"} 0
redis_latency_percentiles_usec{cmd="mset",quantile="50"} 3.007
redis_latency_percentiles_usec{cmd="mset",quantile="75"} 5.023
redis_latency_percentiles_usec{cmd="mset",quantile="95"} 6.015
redis_latency_percentiles_usec{cmd="mset",quantile="99"} 8.031
redis_latency_percentiles_usec{cmd="mset",quantile="100"} 139.263
redis_latency_percentiles_usec_sum{cmd="mset"} 381537
redis_latency_percentiles_usec_count{cmd="mset"} 100000
redis_latency_percentiles_usec{cmd="ping",quantile="0"} 0
redis_latency_percentiles_usec{cmd="ping",quantile="50"} 0.001
redis_latency_percentiles_usec{cmd="ping",quantile="75"} 0.001
redis_latency_percentiles_usec{cmd="ping",quantile="95"} 1.003
redis_latency_percentiles_usec{cmd="ping",quantile="99"} 1.003
redis_latency_percentiles_usec{cmd="ping",quantile="100"} 49.151
redis_latency_percentiles_usec_sum{cmd="ping"} 39815
redis_latency_percentiles_usec_count{cmd="ping"} 200000
redis_latency_percentiles_usec{cmd="rpop",quantile="0"} 0
redis_latency_percentiles_usec{cmd="rpop",quantile="50"} 1.003
redis_latency_percentiles_usec{cmd="rpop",quantile="75"} 1.003
redis_latency_percentiles_usec{cmd="rpop",quantile="95"} 2.007
redis_latency_percentiles_usec{cmd="rpop",quantile="99"} 3.007
redis_latency_percentiles_usec{cmd="rpop",quantile="100"} 52.223
redis_latency_percentiles_usec_sum{cmd="rpop"} 109759
redis_latency_percentiles_usec_count{cmd="rpop"} 100000
redis_latency_percentiles_usec{cmd="rpush",quantile="0"} 0
redis_latency_percentiles_usec{cmd="rpush",quantile="50"} 1.003
redis_latency_percentiles_usec{cmd="rpush",quantile="75"} 1.003
redis_latency_percentiles_usec{cmd="rpush",quantile="95"} 1.003
redis_latency_percentiles_usec{cmd="rpush",quantile="99"} 3.007
redis_latency_percentiles_usec{cmd="rpush",quantile="100"} 61.183
redis_latency_percentiles_usec_sum{cmd="rpush"} 69972
redis_latency_percentiles_usec_count{cmd="rpush"} 100000
redis_latency_percentiles_usec{cmd="sadd",quantile="0"} 0
redis_latency_percentiles_usec{cmd="sadd",quantile="50"} 1.003
redis_latency_percentiles_usec{cmd="sadd",quantile="75"} 1.003
redis_latency_percentiles_usec{cmd="sadd",quantile="95"} 1.003
redis_latency_percentiles_usec{cmd="sadd",quantile="99"} 2.007
redis_latency_percentiles_usec{cmd="sadd",quantile="100"} 27.007
redis_latency_percentiles_usec_sum{cmd="sadd"} 54369
redis_latency_percentiles_usec_count{cmd="sadd"} 100000
redis_latency_percentiles_usec{cmd="set",quantile="0"} 0
redis_latency_percentiles_usec{cmd="set",quantile="50"} 1.003
redis_latency_percentiles_usec{cmd="set",quantile="75"} 1.003
redis_latency_percentiles_usec{cmd="set",quantile="95"} 1.003
redis_latency_percentiles_usec{cmd="set",quantile="99"} 2.007
redis_latency_percentiles_usec{cmd="set",quantile="100"} 166.911
redis_latency_percentiles_usec_sum{cmd="set"} 76770
redis_latency_percentiles_usec_count{cmd="set"} 100000
redis_latency_percentiles_usec{cmd="slowlog|get",quantile="0"} 0
redis_latency_percentiles_usec{cmd="slowlog|get",quantile="50"} 3.007
redis_latency_percentiles_usec{cmd="slowlog|get",quantile="75"} 3.007
redis_latency_percentiles_usec{cmd="slowlog|get",quantile="95"} 3.007
redis_latency_percentiles_usec{cmd="slowlog|get",quantile="99"} 3.007
redis_latency_percentiles_usec{cmd="slowlog|get",quantile="100"} 3.007
redis_latency_percentiles_usec_sum{cmd="slowlog|get"} 3
redis_latency_percentiles_usec_count{cmd="slowlog|get"} 1
redis_latency_percentiles_usec{cmd="slowlog|len",quantile="0"} 0
redis_latency_percentiles_usec{cmd="slowlog|len",quantile="50"} 2.007
redis_latency_percentiles_usec{cmd="slowlog|len",quantile="75"} 2.007
redis_latency_percentiles_usec{cmd="slowlog|len",quantile="95"} 2.007
redis_latency_percentiles_usec{cmd="slowlog|len",quantile="99"} 2.007
redis_latency_percentiles_usec{cmd="slowlog|len",quantile="100"} 2.007
redis_latency_percentiles_usec_sum{cmd="slowlog|len"} 2
redis_latency_percentiles_usec_count{cmd="slowlog|len"} 1
redis_latency_percentiles_usec{cmd="spop",quantile="0"} 0
redis_latency_percentiles_usec{cmd="spop",quantile="50"} 0.001
redis_latency_percentiles_usec{cmd="spop",quantile="75"} 1.003
redis_latency_percentiles_usec{cmd="spop",quantile="95"} 1.003
redis_latency_percentiles_usec{cmd="spop",quantile="99"} 2.007
redis_latency_percentiles_usec{cmd="spop",quantile="100"} 52.223
redis_latency_percentiles_usec_sum{cmd="spop"} 48228
redis_latency_percentiles_usec_count{cmd="spop"} 100000
redis_latency_percentiles_usec{cmd="zadd",quantile="0"} 0
redis_latency_percentiles_usec{cmd="zadd",quantile="50"} 1.003
redis_latency_percentiles_usec{cmd="zadd",quantile="75"} 2.007
redis_latency_percentiles_usec{cmd="zadd",quantile="95"} 3.007
redis_latency_percentiles_usec{cmd="zadd",quantile="99"} 6.015
redis_latency_percentiles_usec{cmd="zadd",quantile="100"} 823.295
redis_latency_percentiles_usec_sum{cmd="zadd"} 146737
redis_latency_percentiles_usec_count{cmd="zadd"} 100000
redis_latency_percentiles_usec{cmd="zpopmin",quantile="0"} 0
redis_latency_percentiles_usec{cmd="zpopmin",quantile="50"} 0.001
redis_latency_percentiles_usec{cmd="zpopmin",quantile="75"} 1.003
redis_latency_percentiles_usec{cmd="zpopmin",quantile="95"} 1.003
redis_latency_percentiles_usec{cmd="zpopmin",quantile="99"} 2.007
redis_latency_percentiles_usec{cmd="zpopmin",quantile="100"} 112.127
redis_latency_percentiles_usec_sum{cmd="zpopmin"} 49284
redis_latency_percentiles_usec_count{cmd="zpopmin"} 100000
```

It's important to emphasize that o Redis we don't store summaries --- we preserve the entire sketch of data --- meaning that if you want to extend the exported percentiles it's retroactive to the current command stats already present on Redis =)