### PR TITLE
fixed TestLatencyStats() wrong check

### DIFF
--- a/exporter/info_test.go
+++ b/exporter/info_test.go
@@ -111,7 +111,7 @@ func TestLatencyStats(t *testing.T) {
 	e := getTestExporterWithAddr(redisSevenAddr)
 	setupDBKeys(t, redisSevenAddr)
 
-	want := map[string]bool{"redis_latency_percentiles_usec": false}
+	want := map[string]bool{"latency_percentiles_usec": false}
 	commandStatsCheck(t, e, want)
 	deleteKeysFromDB(t, redisSevenAddr)
 }


### PR DESCRIPTION
This PR fixes an added issue on https://github.com/oliver006/redis_exporter/pull/652#issuecomment-1141097840. 

check of failure

```
$ TEST_REDIS7_URI=redis://127.0.0.1:6379 go test exporter/*.go --test.run TestLatencyStats* -test.v
=== RUN   TestLatencyStats
    info_test.go:135: didn't find aalatency_percentiles_usec
--- FAIL: TestLatencyStats (0.06s)
FAIL
FAIL    command-line-arguments  0.067s
FAIL
```

check of fix:

```
$ TEST_REDIS7_URI=redis://127.0.0.1:6379 go test exporter/*.go --test.run TestLatencyStats* -test.v
=== RUN   TestLatencyStats
--- PASS: TestLatencyStats (0.06s)
PASS
ok      command-line-arguments  0.061s

```