### PR TITLE
Add securityContext to kubernetes example for

### DIFF
--- a/contrib/k8s-redis-and-exporter-deployment.yaml
+++ b/contrib/k8s-redis-and-exporter-deployment.yaml
@@ -33,6 +33,13 @@ spec:
         - containerPort: 6379
       - name: redis-exporter
         image: oliver006/redis_exporter:latest
+        securityContext:
+          runAsUser: 59000
+          runAsGroup: 59000
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
I suggest adding security context to the Kubernetes example. It will allow users to easier find the required user/group and more securely and deploy this exporter into their clusters.

I tested this securityContext in my deployment. All works fine