### PR TITLE
include user info in redis_connected_clients_details

### DIFF
--- a/exporter/clients.go
+++ b/exporter/clients.go
@@ -65,7 +65,7 @@ func parseClientListString(clientInfo string) (*ClientInfo, bool) {
 			connectedClient.Flags = vPart[1]
 		case "db":
 			connectedClient.Db = vPart[1]
-		case "omen":
+		case "omem":
 			connectedClient.OMem = vPart[1]
 		case "cmd":
 			connectedClient.Cmd = vPart[1]

--- a/exporter/clients.go
+++ b/exporter/clients.go
@@ -16,7 +16,7 @@ import (
 	id=11 addr=127.0.0.1:63508 fd=8 name= age=6321 idle=6320 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=setex
 	id=14 addr=127.0.0.1:64958 fd=9 name= age=5 idle=0 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=26 qbuf-free=32742 obl=0 oll=0 omem=0 events=r cmd=client
 */
-func parseClientListString(clientInfo string) ([]string, bool) {
+func parseClientListString(clientInfo string) (map[string]string, bool) {
 	if matched, _ := regexp.MatchString(`^id=\d+ addr=\d+`, clientInfo); !matched {
 		return nil, false
 	}
@@ -35,31 +35,23 @@ func parseClientListString(clientInfo string) ([]string, bool) {
 		log.Debugf("cloud not parse age field(%s): %s", connectedClient["age"], err.Error())
 		return nil, false
 	}
+	connectedClient["created_at"] = createdAtTs
 
 	idleSinceTs, err := durationFieldToTimestamp(connectedClient["idle"])
 	if err != nil {
 		log.Debugf("cloud not parse idle field(%s): %s", connectedClient["idle"], err.Error())
 		return nil, false
 	}
+	connectedClient["idle_since"] = idleSinceTs
 
 	hostPortString := strings.Split(connectedClient["addr"], ":")
 	if len(hostPortString) != 2 {
 		return nil, false
 	}
+	connectedClient["host"] = hostPortString[0]
+	connectedClient["port"] = hostPortString[1]
 
-	return []string{
-		connectedClient["name"],
-		createdAtTs,
-		idleSinceTs,
-		connectedClient["flags"],
-		connectedClient["db"],
-		connectedClient["omem"],
-		connectedClient["cmd"],
-
-		hostPortString[0], // host
-		hostPortString[1], // port
-	}, true
-
+	return connectedClient, true
 }
 
 func durationFieldToTimestamp(field string) (string, error) {
@@ -80,14 +72,22 @@ func (e *Exporter) extractConnectedClientMetrics(ch chan<- prometheus.Metric, c 
 
 	for _, c := range strings.Split(reply, "\n") {
 		if lbls, ok := parseClientListString(c); ok {
-
-			// port is the last item, we'll trim it if it's not needed
-			if !e.options.ExportClientsInclPort {
-				lbls = lbls[:len(lbls)-1]
+			connectedClientsLabels := []string{"name", "created_at", "idle_since", "flags", "db", "omem", "cmd", "host"}
+			connectedClientsLabelsValues := []string{lbls["name"], lbls["created_at"], lbls["idle_since"], lbls["flags"], lbls["db"], lbls["omem"], lbls["cmd"], lbls["host"]}
+			if e.options.ExportClientsInclPort {
+				connectedClientsLabels = append(connectedClientsLabels, "port")
+				connectedClientsLabelsValues = append(connectedClientsLabelsValues, lbls["port"])
 			}
+			if user, ok := lbls["user"]; ok {
+				connectedClientsLabels = append(connectedClientsLabels, "user")
+				connectedClientsLabelsValues = append(connectedClientsLabelsValues, user)
+			}
+
+			e.metricDescriptions["connected_clients_details"] = newMetricDescr(e.options.Namespace, "connected_clients_details", "Details about connected clients", connectedClientsLabels)
+
 			e.registerConstMetricGauge(
 				ch, "connected_clients_details", 1.0,
-				lbls...,
+				connectedClientsLabelsValues...,
 			)
 		}
 	}

--- a/exporter/clients_test.go
+++ b/exporter/clients_test.go
@@ -66,15 +66,15 @@ func TestParseClientListString(t *testing.T) {
 		{
 			in:           "id=11 addr=127.0.0.1:63508 fd=8 name= age=6321 idle=6320 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=setex",
 			expectedOk:   true,
-			expectedLbls: ClientInfo{CreatedAt: convertDurationToTimestampString("6321"), IdleSince: convertDurationToTimestampString("6320"), Flags: "n", Db: "0", OMem: "0", Cmd: "setex", Host: "127.0.0.1", Port: "63508"},
+			expectedLbls: ClientInfo{CreatedAt: convertDurationToTimestampString("6321"), IdleSince: convertDurationToTimestampString("6320"), Flags: "N", Db: "0", OMem: "0", Cmd: "setex", Host: "127.0.0.1", Port: "63508"},
 		}, {
 			in:           "id=14 addr=127.0.0.1:64958 fd=9 name=foo age=5 idle=0 flags=N db=1 sub=0 psub=0 multi=-1 qbuf=26 qbuf-free=32742 obl=0 oll=0 omem=0 events=r cmd=client",
 			expectedOk:   true,
-			expectedLbls: ClientInfo{CreatedAt: convertDurationToTimestampString("5"), IdleSince: convertDurationToTimestampString("0"), Flags: "N", Db: "1", OMem: "0", Cmd: "client", Host: "127.0.0.1", Port: "64958"},
+			expectedLbls: ClientInfo{Name: "foo", CreatedAt: convertDurationToTimestampString("5"), IdleSince: convertDurationToTimestampString("0"), Flags: "N", Db: "1", OMem: "0", Cmd: "client", Host: "127.0.0.1", Port: "64958"},
 		}, {
 			in:           "id=14 addr=127.0.0.1:64959 fd=9 name= age=5 idle=0 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=26 qbuf-free=32742 obl=0 oll=0 omem=0 events=r cmd=client user=default resp=3",
 			expectedOk:   true,
-			expectedLbls: ClientInfo{CreatedAt: convertDurationToTimestampString("5"), IdleSince: convertDurationToTimestampString("0"), Flags: "N", Db: "0", OMem: "0", Cmd: "client", Host: "127.0.0.1", Port: "64959", User: "default", Resp: "2"},
+			expectedLbls: ClientInfo{CreatedAt: convertDurationToTimestampString("5"), IdleSince: convertDurationToTimestampString("0"), Flags: "N", Db: "0", OMem: "0", Cmd: "client", Host: "127.0.0.1", Port: "64959", User: "default", Resp: "3"},
 		}, {
 			in:         "id=14 addr=127.0.0.1:64958 fd=9 name=foo age=ABCDE idle=0 flags=N db=1 sub=0 psub=0 multi=-1 qbuf=26 qbuf-free=32742 obl=0 oll=0 omem=0 events=r cmd=client",
 			expectedOk: false,

--- a/exporter/clients_test.go
+++ b/exporter/clients_test.go
@@ -95,13 +95,8 @@ func TestParseClientListString(t *testing.T) {
 			}
 			continue
 		}
-		mismatch := false
 
-		if lbls != &tst.expectedLbls {
-			mismatch = true
-		}
-
-		if mismatch {
+		if *lbls != tst.expectedLbls {
 			t.Errorf("TestParseClientListString( %s ) error. Given: %s Wanted: %s", tst.in, lbls, tst.expectedLbls)
 		}
 	}

--- a/exporter/clients_test.go
+++ b/exporter/clients_test.go
@@ -1,6 +1,7 @@
 package exporter
 
 import (
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -92,7 +93,8 @@ func TestParseClientListString(t *testing.T) {
 			continue
 		}
 		mismatch := false
-		for idx, l := range lbls {
+		for idx, l := range reflect.VisibleFields(ClientInfo) {
+		https: //stackoverflow.com/questions/18926303/iterate-through-the-fields-of-a-struct-in-go
 			if l != tst.expectedLbls[idx] {
 				mismatch = true
 				break

--- a/exporter/clients_test.go
+++ b/exporter/clients_test.go
@@ -99,7 +99,6 @@ func TestParseClientListString(t *testing.T) {
 
 		if lbls != &tst.expectedLbls {
 			mismatch = true
-			break
 		}
 
 		if mismatch {

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -334,11 +334,6 @@ func NewRedisExporter(redisURI string, opts Options) (*Exporter, error) {
 
 	e.metricDescriptions = map[string]*prometheus.Desc{}
 
-	connectedClientsLabels := []string{"name", "created_at", "idle_since", "flags", "db", "omem", "cmd", "host"}
-	if e.options.ExportClientsInclPort {
-		connectedClientsLabels = append(connectedClientsLabels, "port")
-	}
-
 	for k, desc := range map[string]struct {
 		txt  string
 		lbls []string
@@ -351,7 +346,6 @@ func NewRedisExporter(redisURI string, opts Options) (*Exporter, error) {
 		"latency_percentiles_usec":                     {txt: `A summary of latency percentile distribution per command`, lbls: []string{"cmd"}},
 		"config_key_value":                             {txt: `Config key and value`, lbls: []string{"key", "value"}},
 		"config_value":                                 {txt: `Config key and value as metric`, lbls: []string{"key"}},
-		"connected_clients_details":                    {txt: "Details about connected clients", lbls: connectedClientsLabels},
 		"connected_slave_lag_seconds":                  {txt: "Lag of connected slave", lbls: []string{"slave_ip", "slave_port", "slave_state"}},
 		"connected_slave_offset_bytes":                 {txt: "Offset of connected slave", lbls: []string{"slave_ip", "slave_port", "slave_state"}},
 		"db_avg_ttl_seconds":                           {txt: "Avg TTL in seconds", lbls: []string{"db"}},

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -70,6 +70,11 @@ func getTestExporterWithAddr(addr string) *Exporter {
 	return e
 }
 
+func getTestExporterWithAddrAndOptions(addr string, opt Options) *Exporter {
+	e, _ := NewRedisExporter(addr, opt)
+	return e
+}
+
 func setupKeys(t *testing.T, c redis.Conn, dbNumStr string) error {
 	if _, err := c.Do("SELECT", dbNumStr); err != nil {
 		log.Printf("setupDBKeys() - couldn't setup redis, err: %s ", err)

--- a/main.go
+++ b/main.go
@@ -84,7 +84,7 @@ func main() {
 		setClientName        = flag.Bool("set-client-name", getEnvBool("REDIS_EXPORTER_SET_CLIENT_NAME", true), "Whether to set client name to redis_exporter")
 		isTile38             = flag.Bool("is-tile38", getEnvBool("REDIS_EXPORTER_IS_TILE38", false), "Whether to scrape Tile38 specific metrics")
 		isCluster            = flag.Bool("is-cluster", getEnvBool("REDIS_EXPORTER_IS_CLUSTER", false), "Whether this is a redis cluster (Enable this if you need to fetch key level data on a Redis Cluster).")
-		exportClientList     = flag.Bool("export-client-list", getEnvBool("REDIS_EXPORTER_EXPORT_CLIENT_LIST", true), "Whether to scrape Client List specific metrics")
+		exportClientList     = flag.Bool("export-client-list", getEnvBool("REDIS_EXPORTER_EXPORT_CLIENT_LIST", false), "Whether to scrape Client List specific metrics")
 		exportClientPort     = flag.Bool("export-client-port", getEnvBool("REDIS_EXPORTER_EXPORT_CLIENT_PORT", false), "Whether to include the client's port when exporting the client list. Warning: including the port increases the number of metrics generated and will make your Prometheus server take up more memory")
 		showVersion          = flag.Bool("version", false, "Show version information and exit")
 		redisMetricsOnly     = flag.Bool("redis-only-metrics", getEnvBool("REDIS_EXPORTER_REDIS_ONLY_METRICS", false), "Whether to also export go runtime metrics")

--- a/main.go
+++ b/main.go
@@ -84,7 +84,7 @@ func main() {
 		setClientName        = flag.Bool("set-client-name", getEnvBool("REDIS_EXPORTER_SET_CLIENT_NAME", true), "Whether to set client name to redis_exporter")
 		isTile38             = flag.Bool("is-tile38", getEnvBool("REDIS_EXPORTER_IS_TILE38", false), "Whether to scrape Tile38 specific metrics")
 		isCluster            = flag.Bool("is-cluster", getEnvBool("REDIS_EXPORTER_IS_CLUSTER", false), "Whether this is a redis cluster (Enable this if you need to fetch key level data on a Redis Cluster).")
-		exportClientList     = flag.Bool("export-client-list", getEnvBool("REDIS_EXPORTER_EXPORT_CLIENT_LIST", false), "Whether to scrape Client List specific metrics")
+		exportClientList     = flag.Bool("export-client-list", getEnvBool("REDIS_EXPORTER_EXPORT_CLIENT_LIST", true), "Whether to scrape Client List specific metrics")
 		exportClientPort     = flag.Bool("export-client-port", getEnvBool("REDIS_EXPORTER_EXPORT_CLIENT_PORT", false), "Whether to include the client's port when exporting the client list. Warning: including the port increases the number of metrics generated and will make your Prometheus server take up more memory")
 		showVersion          = flag.Bool("version", false, "Show version information and exit")
 		redisMetricsOnly     = flag.Bool("redis-only-metrics", getEnvBool("REDIS_EXPORTER_REDIS_ONLY_METRICS", false), "Whether to also export go runtime metrics")


### PR DESCRIPTION
Related to issue #775, redis_connected_clients_details don't show user info.

This is still a WIP as there are no test yet. But it tries to follow [comment](https://github.com/oliver006/redis_exporter/issues/775#issuecomment-1461222214)

Please let me know if this approach and code changes are likely to be merged, and I will finish it. Otherwise feel free to reject it.

_parseClientListString_ now returns a map containing the parsed output of the client list reply
_extractConnectedClientMetrics_ now creates the metric description. Instead during startup at _exporter.go_

Maybe this is not somehow very efficient as they are created at every scrape.