### PR TITLE
feat: Add redis.password-file hot reload via `/-/reload`

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -76,6 +76,7 @@ type Options struct {
 	MetricsPath           string
 	RedisMetricsOnly      bool
 	PingOnConnect         bool
+	RedisPwdFile          string
 	Registry              *prometheus.Registry
 	BuildInfo             BuildInfo
 }
@@ -428,6 +429,7 @@ func NewRedisExporter(redisURI string, opts Options) (*Exporter, error) {
 	e.mux.HandleFunc("/", e.indexHandler)
 	e.mux.HandleFunc("/scrape", e.scrapeHandler)
 	e.mux.HandleFunc("/health", e.healthHandler)
+	e.mux.HandleFunc("/-/reload", e.ReloadPwdFile)
 
 	return e, nil
 }

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -429,7 +429,7 @@ func NewRedisExporter(redisURI string, opts Options) (*Exporter, error) {
 	e.mux.HandleFunc("/", e.indexHandler)
 	e.mux.HandleFunc("/scrape", e.scrapeHandler)
 	e.mux.HandleFunc("/health", e.healthHandler)
-	e.mux.HandleFunc("/-/reload", e.ReloadPwdFile)
+	e.mux.HandleFunc("/-/reload", e.reloadPwdFile)
 
 	return e, nil
 }

--- a/exporter/http.go
+++ b/exporter/http.go
@@ -95,8 +95,8 @@ func (e *Exporter) reloadPwdFile(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "There is no pwd file specified", http.StatusBadRequest)
 		return
 	}
-	passwordMap, err := LoadPwdFile(e.options.RedisPwdFile)
 	log.Debugf("Reload redisPwdFile")
+	passwordMap, err := LoadPwdFile(e.options.RedisPwdFile)
 	if err != nil {
 		log.Errorf("Error reloading redis passwords from file %s, err: %s", e.options.RedisPwdFile, err)
 		http.Error(w, "failed to reload passwords file: "+err.Error(), http.StatusInternalServerError)

--- a/exporter/http_test.go
+++ b/exporter/http_test.go
@@ -289,9 +289,9 @@ func TestHttpHandlers(t *testing.T) {
 }
 
 func TestReloadHandlers(t *testing.T) {
-	// if os.Getenv("TEST_PWD_REDIS_URI") == "" {
-	// 	t.Skipf("TEST_PWD_REDIS_URI not set - skipping")
-	// }
+	if os.Getenv("TEST_PWD_REDIS_URI") == "" {
+		t.Skipf("TEST_PWD_REDIS_URI not set - skipping")
+	}
 
 	eWithPwdfile, _ := NewRedisExporter(os.Getenv("TEST_PWD_REDIS_URI"), Options{Namespace: "test", Registry: prometheus.NewRegistry(), RedisPwdFile: "../contrib/sample-pwd-file.json"})
 	ts := httptest.NewServer(eWithPwdfile)
@@ -331,6 +331,28 @@ func TestReloadHandlers(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("path: %s", tst.path), func(t *testing.T) {
 			body := downloadURL(t, ts2.URL+tst.path)
+			if !strings.Contains(body, tst.want) {
+				t.Fatalf(`error, expected string "%s" in body, got body: \n\n%s`, tst.want, body)
+			}
+		})
+	}
+
+	eWithMalformedPwdfile, _ := NewRedisExporter(os.Getenv("TEST_PWD_REDIS_URI"), Options{Namespace: "test", Registry: prometheus.NewRegistry(), RedisPwdFile: "../contrib/sample-pwd-file.json-malformed"})
+	ts3 := httptest.NewServer(eWithMalformedPwdfile)
+	defer ts3.Close()
+
+	for _, tst := range []struct {
+		e    *Exporter
+		path string
+		want string
+	}{
+		{
+			path: "/-/reload",
+			want: `failed to reload passwords file: unexpected end of JSON input`,
+		},
+	} {
+		t.Run(fmt.Sprintf("path: %s", tst.path), func(t *testing.T) {
+			body := downloadURL(t, ts3.URL+tst.path)
 			if !strings.Contains(body, tst.want) {
 				t.Fatalf(`error, expected string "%s" in body, got body: \n\n%s`, tst.want, body)
 			}

--- a/exporter/http_test.go
+++ b/exporter/http_test.go
@@ -288,6 +288,56 @@ func TestHttpHandlers(t *testing.T) {
 	}
 }
 
+func TestReloadHandlers(t *testing.T) {
+	// if os.Getenv("TEST_PWD_REDIS_URI") == "" {
+	// 	t.Skipf("TEST_PWD_REDIS_URI not set - skipping")
+	// }
+
+	eWithPwdfile, _ := NewRedisExporter(os.Getenv("TEST_PWD_REDIS_URI"), Options{Namespace: "test", Registry: prometheus.NewRegistry(), RedisPwdFile: "../contrib/sample-pwd-file.json"})
+	ts := httptest.NewServer(eWithPwdfile)
+	defer ts.Close()
+
+	for _, tst := range []struct {
+		e    *Exporter
+		path string
+		want string
+	}{
+		{
+			path: "/-/reload",
+			want: `ok`,
+		},
+	} {
+		t.Run(fmt.Sprintf("path: %s", tst.path), func(t *testing.T) {
+			body := downloadURL(t, ts.URL+tst.path)
+			if !strings.Contains(body, tst.want) {
+				t.Fatalf(`error, expected string "%s" in body, got body: \n\n%s`, tst.want, body)
+			}
+		})
+	}
+
+	eWithnoPwdfile, _ := NewRedisExporter(os.Getenv("TEST_PWD_REDIS_URI"), Options{Namespace: "test", Registry: prometheus.NewRegistry()})
+	ts2 := httptest.NewServer(eWithnoPwdfile)
+	defer ts2.Close()
+
+	for _, tst := range []struct {
+		e    *Exporter
+		path string
+		want string
+	}{
+		{
+			path: "/-/reload",
+			want: `There is no pwd file specified`,
+		},
+	} {
+		t.Run(fmt.Sprintf("path: %s", tst.path), func(t *testing.T) {
+			body := downloadURL(t, ts2.URL+tst.path)
+			if !strings.Contains(body, tst.want) {
+				t.Fatalf(`error, expected string "%s" in body, got body: \n\n%s`, tst.want, body)
+			}
+		})
+	}
+}
+
 func downloadURL(t *testing.T, u string) string {
 	_, res := downloadURLWithStatusCode(t, u)
 	return res

--- a/exporter/pwd_file.go
+++ b/exporter/pwd_file.go
@@ -23,7 +23,7 @@ func LoadPwdFile(passwordFile string) (map[string]string, error) {
 		return nil, err
 	}
 
-	log.Errorf("Loaded %d entries from %s", len(res), passwordFile)
+	log.Infof("Loaded %d entries from %s", len(res), passwordFile)
 	for k := range res {
 		log.Debugf("%s", k)
 	}

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ func getEnvInt64(key string, defaultVal int64) int64 {
 
 func main() {
 	var (
-		redisAddr            = flag.String("redis.addr", getEnv("REDIS_ADDR", "redis://localhost:6379"), "Address of the Redis instance to scrape")
+		redisAddr            = flag.String("redis.addr", getEnv("REDIS_ADDR", ""), "Address of the Redis instance to scrape")
 		redisUser            = flag.String("redis.user", getEnv("REDIS_USER", ""), "User name to use for authentication (Redis ACL for Redis 6.0 and newer)")
 		redisPwd             = flag.String("redis.password", getEnv("REDIS_PASSWORD", ""), "Password of the Redis instance to scrape")
 		redisPwdFile         = flag.String("redis.password-file", getEnv("REDIS_PASSWORD_FILE", ""), "Password file of the Redis instance to scrape")
@@ -183,6 +183,7 @@ func main() {
 			MetricsPath:           *metricPath,
 			RedisMetricsOnly:      *redisMetricsOnly,
 			PingOnConnect:         *pingOnConnect,
+			RedisPwdFile:          *redisPwdFile,
 			Registry:              registry,
 			BuildInfo: exporter.BuildInfo{
 				Version:   BuildVersion,

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ func getEnvInt64(key string, defaultVal int64) int64 {
 
 func main() {
 	var (
-		redisAddr            = flag.String("redis.addr", getEnv("REDIS_ADDR", ""), "Address of the Redis instance to scrape")
+		redisAddr            = flag.String("redis.addr", getEnv("REDIS_ADDR", "redis://localhost:6379"), "Address of the Redis instance to scrape")
 		redisUser            = flag.String("redis.user", getEnv("REDIS_USER", ""), "User name to use for authentication (Redis ACL for Redis 6.0 and newer)")
 		redisPwd             = flag.String("redis.password", getEnv("REDIS_PASSWORD", ""), "Password of the Redis instance to scrape")
 		redisPwdFile         = flag.String("redis.password-file", getEnv("REDIS_PASSWORD_FILE", ""), "Password file of the Redis instance to scrape")


### PR DESCRIPTION
1. add redis.password-file hot reload via `/-/reload`#727
2. fix a typo which log `level=error msg="Loaded 3 entries from ./redis-pwd-file.json"`
3. change `redis.addr` default "",explain this,when I use `redis.password-file` most time ,I don not need a `redis.addr`,so this will make continuously outputted logs `level=error msg="Couldn't connect to redis instance (redis://localhost:6379)"` disappear