### PR TITLE
ci: add sdist with vendor for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+
+on:
+  push:
+    tags: [tst-v*, v*]
+
+jobs:
+  sdist:
+    runs-on: ubuntu-latest
+    environment: release
+
+    permissions:
+      contents: write # Used to authenticate github release publish
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.22'
+
+    - name: Setup Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libarchive-tools # for bsdtar
+
+    - name: Generate sdist
+      run: |
+        VERSION=${GITHUB_REF_NAME#v}
+        go mod vendor
+        tar -czf ../redis_exporter-${VERSION}.tar.gz --transform "s,^,redis_exporter-${VERSION}/," *
+        tar -cJf ../redis_exporter-${VERSION}.tar.xz --transform "s,^,redis_exporter-${VERSION}/," *
+        bsdtar -c -a -f ../redis_exporter-${VERSION}.zip -s ",^,redis_exporter-${VERSION}/," *
+
+    - name: Create GitHub release
+      uses: softprops/action-gh-release@v2
+      with:
+        files: |
+          ../redis_exporter-*.tar.gz
+          ../redis_exporter-*.tar.xz
+          ../redis_exporter-*.zip
+        fail_on_unmatched_files: true
+        draft: true


### PR DESCRIPTION
OK, this is the first part for https://github.com/oliver006/redis_exporter/issues/793, the simplest one. This job will create a useful for distributions source tarball, which contains the code & `go mod vendor` run inside.

### Required setup in configuration:

1. Go to repository settings.
2. In left sidebar choose "Environments"
3. Click on add new environment
4. name it `release` (this is the name I used here, you can choose another one and I'll modify it here)
5. I recommend to setup `Required reviewers` and add yourself in there. When you create a new tag, you'll receive an email where you need to approve the run. It helps with accidental tag push before everything is pushed :)
6. Click on "Save protection rules"

### Workflow explanation:

1. Triggered automatically (after approval) when you push tags that start with `v`, for example `v1.51.0`.
2. checkouts and setups go1.19
3. runs `go mod vendor`
4. create a `.tar.gz` file containing a directory named `redis_exporter-v${version}`, under which all content is found including `vendor/` dir.
5. Create a new release on github, adds as asset the sdist, marks the release as draft. This is done so you can once again verify it, add release notes (for example changelog) and then manually publish.

I've tested this workflow on my fork, it generated this file [redis_exporter-0.0.9999.tar.gz](https://github.com/oliver006/redis_exporter/files/11433662/redis_exporter-0.0.9999.tar.gz) (yes, I used quite weird version)

### My next step

Add another job to this workflow, which would build the binaries, and add them as assets to the same draft release.