### PR TITLE
feat: make value extraction configurable for keys

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -46,39 +46,40 @@ type Exporter struct {
 }
 
 type Options struct {
-	User                  string
-	Password              string
-	Namespace             string
-	PasswordMap           map[string]string
-	ConfigCommandName     string
-	CheckKeys             string
-	CheckSingleKeys       string
-	CheckStreams          string
-	CheckSingleStreams    string
-	CheckKeysBatchSize    int64
-	CheckKeyGroups        string
-	MaxDistinctKeyGroups  int64
-	CountKeys             string
-	LuaScript             map[string][]byte
-	ClientCertFile        string
-	ClientKeyFile         string
-	CaCertFile            string
-	InclConfigMetrics     bool
-	RedactConfigMetrics   bool
-	InclSystemMetrics     bool
-	SkipTLSVerification   bool
-	SetClientName         bool
-	IsTile38              bool
-	IsCluster             bool
-	ExportClientList      bool
-	ExportClientsInclPort bool
-	ConnectionTimeouts    time.Duration
-	MetricsPath           string
-	RedisMetricsOnly      bool
-	PingOnConnect         bool
-	RedisPwdFile          string
-	Registry              *prometheus.Registry
-	BuildInfo             BuildInfo
+	User                       string
+	Password                   string
+	Namespace                  string
+	PasswordMap                map[string]string
+	ConfigCommandName          string
+	CheckKeys                  string
+	CheckSingleKeys            string
+	CheckStreams               string
+	CheckSingleStreams         string
+	CheckKeysBatchSize         int64
+	CheckKeyGroups             string
+	MaxDistinctKeyGroups       int64
+	CountKeys                  string
+	LuaScript                  map[string][]byte
+	ClientCertFile             string
+	ClientKeyFile              string
+	CaCertFile                 string
+	InclConfigMetrics          bool
+	IncludeKeysValuesAsMetrics bool
+	RedactConfigMetrics        bool
+	InclSystemMetrics          bool
+	SkipTLSVerification        bool
+	SetClientName              bool
+	IsTile38                   bool
+	IsCluster                  bool
+	ExportClientList           bool
+	ExportClientsInclPort      bool
+	ConnectionTimeouts         time.Duration
+	MetricsPath                string
+	RedisMetricsOnly           bool
+	PingOnConnect              bool
+	RedisPwdFile               string
+	Registry                   *prometheus.Registry
+	BuildInfo                  BuildInfo
 }
 
 // NewRedisExporter returns a new exporter of Redis metrics.

--- a/exporter/keys.go
+++ b/exporter/keys.go
@@ -115,7 +115,7 @@ func (e *Exporter) extractCheckKeyMetrics(ch chan<- prometheus.Metric, c redis.C
 			e.registerConstMetricGauge(ch, "key_size", info.size, dbLabel, k.key)
 
 			// Only run on single value strings
-			if info.keyType == "string" {
+			if info.keyType == "string" && e.options.IncludeKeysValuesAsMetrics {
 				if strVal, err := redis.String(doRedisCmd(c, "GET", k.key)); err == nil {
 					if val, err := strconv.ParseFloat(strVal, 64); err == nil {
 						// Only record value metric if value is float-y

--- a/exporter/keys_test.go
+++ b/exporter/keys_test.go
@@ -25,9 +25,10 @@ func TestKeyValuesAndSizes(t *testing.T) {
 	e, _ := NewRedisExporter(
 		os.Getenv("TEST_REDIS_URI"),
 		Options{
-			Namespace:       "test",
-			CheckSingleKeys: dbNumStrFull + "=" + url.QueryEscape(keys[0]),
-			Registry:        prometheus.NewRegistry()},
+			Namespace:                  "test",
+			CheckSingleKeys:            dbNumStrFull + "=" + url.QueryEscape(keys[0]),
+			IncludeKeysValuesAsMetrics: true,
+			Registry:                   prometheus.NewRegistry()},
 	)
 	ts := httptest.NewServer(e)
 	defer ts.Close()
@@ -54,67 +55,78 @@ func TestKeyValuesAndSizes(t *testing.T) {
 }
 
 func TestKeyValuesAsLabel(t *testing.T) {
-	e, _ := NewRedisExporter(
-		os.Getenv("TEST_REDIS_URI"),
-		Options{
-			Namespace:       "test",
-			CheckSingleKeys: dbNumStrFull + "=" + url.QueryEscape(singleStringKey),
-			Registry:        prometheus.NewRegistry()},
-	)
-	ts := httptest.NewServer(e)
-	defer ts.Close()
+	for _, inc := range []bool{true, false} {
+		e, _ := NewRedisExporter(
+			os.Getenv("TEST_REDIS_URI"),
+			Options{
+				Namespace:                  "test",
+				CheckSingleKeys:            dbNumStrFull + "=" + url.QueryEscape(singleStringKey),
+				IncludeKeysValuesAsMetrics: inc,
+				Registry:                   prometheus.NewRegistry()},
+		)
+		ts := httptest.NewServer(e)
+		defer ts.Close()
 
-	setupDBKeys(t, os.Getenv("TEST_REDIS_URI"))
-	defer deleteKeysFromDB(t, os.Getenv("TEST_REDIS_URI"))
+		setupDBKeys(t, os.Getenv("TEST_REDIS_URI"))
+		defer deleteKeysFromDB(t, os.Getenv("TEST_REDIS_URI"))
 
-	chM := make(chan prometheus.Metric, 10000)
-	go func() {
-		e.Collect(chM)
-		close(chM)
-	}()
+		chM := make(chan prometheus.Metric, 10000)
+		go func() {
+			e.Collect(chM)
+			close(chM)
+		}()
 
-	body := downloadURL(t, ts.URL+"/metrics")
-	for _, want := range []string{
-		"test_key_size",
-		"test_key_value",
-		"key_value_as_string",
-	} {
-		if !strings.Contains(body, want) {
-			t.Fatalf("didn't find %s, body: %s", want, body)
-			return
+		body := downloadURL(t, ts.URL+"/metrics")
+		for _, match := range []string{
+			"key_value_as_string",
+			"test_key_value",
+		} {
+			if inc && !strings.Contains(body, match) {
+				t.Fatalf("didn't find %s with IncludeKeysValuesAsMetrics disabled, body: %s", match, body)
+			} else if !inc && strings.Contains(body, match) {
+				t.Fatalf("didn't expect %s with IncludeKeysValuesAsMetrics enabled, body: %s", match, body)
+			}
 		}
 	}
 }
 
 func TestClusterKeyValuesAndSizes(t *testing.T) {
-	e, _ := NewRedisExporter(
-		os.Getenv("TEST_REDIS_CLUSTER_MASTER_URI"),
-		Options{Namespace: "test", CheckSingleKeys: dbNumStrFull + "=" + url.QueryEscape(keys[0]), IsCluster: true},
-	)
+	for _, inc := range []bool{true, false} {
+		e, _ := NewRedisExporter(
+			os.Getenv("TEST_REDIS_CLUSTER_MASTER_URI"),
+			Options{Namespace: "test", IncludeKeysValuesAsMetrics: inc, CheckSingleKeys: dbNumStrFull + "=" + url.QueryEscape(keys[0]), IsCluster: true},
+		)
 
-	uri := os.Getenv("TEST_REDIS_CLUSTER_MASTER_URI")
+		uri := os.Getenv("TEST_REDIS_CLUSTER_MASTER_URI")
 
-	setupDBKeysCluster(t, uri)
-	defer deleteKeysFromDBCluster(uri)
+		setupDBKeysCluster(t, uri)
+		defer deleteKeysFromDBCluster(uri)
 
-	chM := make(chan prometheus.Metric)
-	go func() {
-		e.Collect(chM)
-		close(chM)
-	}()
+		chM := make(chan prometheus.Metric)
+		go func() {
+			e.Collect(chM)
+			close(chM)
+		}()
 
-	want := map[string]bool{"test_key_size": false, "test_key_value": false}
+		want := map[string]bool{"test_key_size": false, "test_key_value": false}
 
-	for m := range chM {
-		for k := range want {
-			if strings.Contains(m.Desc().String(), k) {
-				want[k] = true
+		for m := range chM {
+			for k := range want {
+				if strings.Contains(m.Desc().String(), k) {
+					want[k] = true
+				}
 			}
 		}
-	}
-	for k, found := range want {
-		if !found {
-			t.Errorf("didn't find %s", k)
+		for k, found := range want {
+			if k == "test_key_value" {
+				if found && !inc {
+					t.Errorf("didn't expect %s with IncludeKeysValuesAsMetrics disabled", k)
+				} else if !found && inc {
+					t.Errorf("didn't find %s with IncludeKeysValuesAsMetrics enabled", k)
+				}
+			} else if !found {
+				t.Errorf("didn't find %s", k)
+			}
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -54,45 +54,46 @@ func getEnvInt64(key string, defaultVal int64) int64 {
 
 func main() {
 	var (
-		redisAddr            = flag.String("redis.addr", getEnv("REDIS_ADDR", "redis://localhost:6379"), "Address of the Redis instance to scrape")
-		redisUser            = flag.String("redis.user", getEnv("REDIS_USER", ""), "User name to use for authentication (Redis ACL for Redis 6.0 and newer)")
-		redisPwd             = flag.String("redis.password", getEnv("REDIS_PASSWORD", ""), "Password of the Redis instance to scrape")
-		redisPwdFile         = flag.String("redis.password-file", getEnv("REDIS_PASSWORD_FILE", ""), "Password file of the Redis instance to scrape")
-		namespace            = flag.String("namespace", getEnv("REDIS_EXPORTER_NAMESPACE", "redis"), "Namespace for metrics")
-		checkKeys            = flag.String("check-keys", getEnv("REDIS_EXPORTER_CHECK_KEYS", ""), "Comma separated list of key-patterns to export value and length/size, searched for with SCAN")
-		checkSingleKeys      = flag.String("check-single-keys", getEnv("REDIS_EXPORTER_CHECK_SINGLE_KEYS", ""), "Comma separated list of single keys to export value and length/size")
-		checkKeyGroups       = flag.String("check-key-groups", getEnv("REDIS_EXPORTER_CHECK_KEY_GROUPS", ""), "Comma separated list of lua regex for grouping keys")
-		checkStreams         = flag.String("check-streams", getEnv("REDIS_EXPORTER_CHECK_STREAMS", ""), "Comma separated list of stream-patterns to export info about streams, groups and consumers, searched for with SCAN")
-		checkSingleStreams   = flag.String("check-single-streams", getEnv("REDIS_EXPORTER_CHECK_SINGLE_STREAMS", ""), "Comma separated list of single streams to export info about streams, groups and consumers")
-		countKeys            = flag.String("count-keys", getEnv("REDIS_EXPORTER_COUNT_KEYS", ""), "Comma separated list of patterns to count (eg: 'db0=production_*,db3=sessions:*'), searched for with SCAN")
-		checkKeysBatchSize   = flag.Int64("check-keys-batch-size", getEnvInt64("REDIS_EXPORTER_CHECK_KEYS_BATCH_SIZE", 1000), "Approximate number of keys to process in each execution, larger value speeds up scanning.\nWARNING: Still Redis is a single-threaded app, huge COUNT can affect production environment.")
-		scriptPath           = flag.String("script", getEnv("REDIS_EXPORTER_SCRIPT", ""), "Comma separated list of path(s) to Redis Lua script(s) for gathering extra metrics")
-		listenAddress        = flag.String("web.listen-address", getEnv("REDIS_EXPORTER_WEB_LISTEN_ADDRESS", ":9121"), "Address to listen on for web interface and telemetry.")
-		metricPath           = flag.String("web.telemetry-path", getEnv("REDIS_EXPORTER_WEB_TELEMETRY_PATH", "/metrics"), "Path under which to expose metrics.")
-		logFormat            = flag.String("log-format", getEnv("REDIS_EXPORTER_LOG_FORMAT", "txt"), "Log format, valid options are txt and json")
-		configCommand        = flag.String("config-command", getEnv("REDIS_EXPORTER_CONFIG_COMMAND", "CONFIG"), "What to use for the CONFIG command")
-		connectionTimeout    = flag.String("connection-timeout", getEnv("REDIS_EXPORTER_CONNECTION_TIMEOUT", "15s"), "Timeout for connection to Redis instance")
-		tlsClientKeyFile     = flag.String("tls-client-key-file", getEnv("REDIS_EXPORTER_TLS_CLIENT_KEY_FILE", ""), "Name of the client key file (including full path) if the server requires TLS client authentication")
-		tlsClientCertFile    = flag.String("tls-client-cert-file", getEnv("REDIS_EXPORTER_TLS_CLIENT_CERT_FILE", ""), "Name of the client certificate file (including full path) if the server requires TLS client authentication")
-		tlsCaCertFile        = flag.String("tls-ca-cert-file", getEnv("REDIS_EXPORTER_TLS_CA_CERT_FILE", ""), "Name of the CA certificate file (including full path) if the server requires TLS client authentication")
-		tlsServerKeyFile     = flag.String("tls-server-key-file", getEnv("REDIS_EXPORTER_TLS_SERVER_KEY_FILE", ""), "Name of the server key file (including full path) if the web interface and telemetry should use TLS")
-		tlsServerCertFile    = flag.String("tls-server-cert-file", getEnv("REDIS_EXPORTER_TLS_SERVER_CERT_FILE", ""), "Name of the server certificate file (including full path) if the web interface and telemetry should use TLS")
-		tlsServerCaCertFile  = flag.String("tls-server-ca-cert-file", getEnv("REDIS_EXPORTER_TLS_SERVER_CA_CERT_FILE", ""), "Name of the CA certificate file (including full path) if the web interface and telemetry should require TLS client authentication")
-		tlsServerMinVersion  = flag.String("tls-server-min-version", getEnv("REDIS_EXPORTER_TLS_SERVER_MIN_VERSION", "TLS1.2"), "Minimum TLS version that is acceptable by the web interface and telemetry when using TLS")
-		maxDistinctKeyGroups = flag.Int64("max-distinct-key-groups", getEnvInt64("REDIS_EXPORTER_MAX_DISTINCT_KEY_GROUPS", 100), "The maximum number of distinct key groups with the most memory utilization to present as distinct metrics per database, the leftover key groups will be aggregated in the 'overflow' bucket")
-		isDebug              = flag.Bool("debug", getEnvBool("REDIS_EXPORTER_DEBUG", false), "Output verbose debug information")
-		setClientName        = flag.Bool("set-client-name", getEnvBool("REDIS_EXPORTER_SET_CLIENT_NAME", true), "Whether to set client name to redis_exporter")
-		isTile38             = flag.Bool("is-tile38", getEnvBool("REDIS_EXPORTER_IS_TILE38", false), "Whether to scrape Tile38 specific metrics")
-		isCluster            = flag.Bool("is-cluster", getEnvBool("REDIS_EXPORTER_IS_CLUSTER", false), "Whether this is a redis cluster (Enable this if you need to fetch key level data on a Redis Cluster).")
-		exportClientList     = flag.Bool("export-client-list", getEnvBool("REDIS_EXPORTER_EXPORT_CLIENT_LIST", false), "Whether to scrape Client List specific metrics")
-		exportClientPort     = flag.Bool("export-client-port", getEnvBool("REDIS_EXPORTER_EXPORT_CLIENT_PORT", false), "Whether to include the client's port when exporting the client list. Warning: including the port increases the number of metrics generated and will make your Prometheus server take up more memory")
-		showVersion          = flag.Bool("version", false, "Show version information and exit")
-		redisMetricsOnly     = flag.Bool("redis-only-metrics", getEnvBool("REDIS_EXPORTER_REDIS_ONLY_METRICS", false), "Whether to also export go runtime metrics")
-		pingOnConnect        = flag.Bool("ping-on-connect", getEnvBool("REDIS_EXPORTER_PING_ON_CONNECT", false), "Whether to ping the redis instance after connecting")
-		inclConfigMetrics    = flag.Bool("include-config-metrics", getEnvBool("REDIS_EXPORTER_INCL_CONFIG_METRICS", false), "Whether to include all config settings as metrics")
-		redactConfigMetrics  = flag.Bool("redact-config-metrics", getEnvBool("REDIS_EXPORTER_REDACT_CONFIG_METRICS", true), "Whether to redact config settings that include potentially sensitive information like passwords")
-		inclSystemMetrics    = flag.Bool("include-system-metrics", getEnvBool("REDIS_EXPORTER_INCL_SYSTEM_METRICS", false), "Whether to include system metrics like e.g. redis_total_system_memory_bytes")
-		skipTLSVerification  = flag.Bool("skip-tls-verification", getEnvBool("REDIS_EXPORTER_SKIP_TLS_VERIFICATION", false), "Whether to to skip TLS verification")
+		redisAddr                  = flag.String("redis.addr", getEnv("REDIS_ADDR", "redis://localhost:6379"), "Address of the Redis instance to scrape")
+		redisUser                  = flag.String("redis.user", getEnv("REDIS_USER", ""), "User name to use for authentication (Redis ACL for Redis 6.0 and newer)")
+		redisPwd                   = flag.String("redis.password", getEnv("REDIS_PASSWORD", ""), "Password of the Redis instance to scrape")
+		redisPwdFile               = flag.String("redis.password-file", getEnv("REDIS_PASSWORD_FILE", ""), "Password file of the Redis instance to scrape")
+		namespace                  = flag.String("namespace", getEnv("REDIS_EXPORTER_NAMESPACE", "redis"), "Namespace for metrics")
+		checkKeys                  = flag.String("check-keys", getEnv("REDIS_EXPORTER_CHECK_KEYS", ""), "Comma separated list of key-patterns to export value and length/size, searched for with SCAN")
+		checkSingleKeys            = flag.String("check-single-keys", getEnv("REDIS_EXPORTER_CHECK_SINGLE_KEYS", ""), "Comma separated list of single keys to export value and length/size")
+		checkKeyGroups             = flag.String("check-key-groups", getEnv("REDIS_EXPORTER_CHECK_KEY_GROUPS", ""), "Comma separated list of lua regex for grouping keys")
+		checkStreams               = flag.String("check-streams", getEnv("REDIS_EXPORTER_CHECK_STREAMS", ""), "Comma separated list of stream-patterns to export info about streams, groups and consumers, searched for with SCAN")
+		checkSingleStreams         = flag.String("check-single-streams", getEnv("REDIS_EXPORTER_CHECK_SINGLE_STREAMS", ""), "Comma separated list of single streams to export info about streams, groups and consumers")
+		countKeys                  = flag.String("count-keys", getEnv("REDIS_EXPORTER_COUNT_KEYS", ""), "Comma separated list of patterns to count (eg: 'db0=production_*,db3=sessions:*'), searched for with SCAN")
+		checkKeysBatchSize         = flag.Int64("check-keys-batch-size", getEnvInt64("REDIS_EXPORTER_CHECK_KEYS_BATCH_SIZE", 1000), "Approximate number of keys to process in each execution, larger value speeds up scanning.\nWARNING: Still Redis is a single-threaded app, huge COUNT can affect production environment.")
+		scriptPath                 = flag.String("script", getEnv("REDIS_EXPORTER_SCRIPT", ""), "Comma separated list of path(s) to Redis Lua script(s) for gathering extra metrics")
+		listenAddress              = flag.String("web.listen-address", getEnv("REDIS_EXPORTER_WEB_LISTEN_ADDRESS", ":9121"), "Address to listen on for web interface and telemetry.")
+		metricPath                 = flag.String("web.telemetry-path", getEnv("REDIS_EXPORTER_WEB_TELEMETRY_PATH", "/metrics"), "Path under which to expose metrics.")
+		logFormat                  = flag.String("log-format", getEnv("REDIS_EXPORTER_LOG_FORMAT", "txt"), "Log format, valid options are txt and json")
+		configCommand              = flag.String("config-command", getEnv("REDIS_EXPORTER_CONFIG_COMMAND", "CONFIG"), "What to use for the CONFIG command")
+		connectionTimeout          = flag.String("connection-timeout", getEnv("REDIS_EXPORTER_CONNECTION_TIMEOUT", "15s"), "Timeout for connection to Redis instance")
+		tlsClientKeyFile           = flag.String("tls-client-key-file", getEnv("REDIS_EXPORTER_TLS_CLIENT_KEY_FILE", ""), "Name of the client key file (including full path) if the server requires TLS client authentication")
+		tlsClientCertFile          = flag.String("tls-client-cert-file", getEnv("REDIS_EXPORTER_TLS_CLIENT_CERT_FILE", ""), "Name of the client certificate file (including full path) if the server requires TLS client authentication")
+		tlsCaCertFile              = flag.String("tls-ca-cert-file", getEnv("REDIS_EXPORTER_TLS_CA_CERT_FILE", ""), "Name of the CA certificate file (including full path) if the server requires TLS client authentication")
+		tlsServerKeyFile           = flag.String("tls-server-key-file", getEnv("REDIS_EXPORTER_TLS_SERVER_KEY_FILE", ""), "Name of the server key file (including full path) if the web interface and telemetry should use TLS")
+		tlsServerCertFile          = flag.String("tls-server-cert-file", getEnv("REDIS_EXPORTER_TLS_SERVER_CERT_FILE", ""), "Name of the server certificate file (including full path) if the web interface and telemetry should use TLS")
+		tlsServerCaCertFile        = flag.String("tls-server-ca-cert-file", getEnv("REDIS_EXPORTER_TLS_SERVER_CA_CERT_FILE", ""), "Name of the CA certificate file (including full path) if the web interface and telemetry should require TLS client authentication")
+		tlsServerMinVersion        = flag.String("tls-server-min-version", getEnv("REDIS_EXPORTER_TLS_SERVER_MIN_VERSION", "TLS1.2"), "Minimum TLS version that is acceptable by the web interface and telemetry when using TLS")
+		maxDistinctKeyGroups       = flag.Int64("max-distinct-key-groups", getEnvInt64("REDIS_EXPORTER_MAX_DISTINCT_KEY_GROUPS", 100), "The maximum number of distinct key groups with the most memory utilization to present as distinct metrics per database, the leftover key groups will be aggregated in the 'overflow' bucket")
+		isDebug                    = flag.Bool("debug", getEnvBool("REDIS_EXPORTER_DEBUG", false), "Output verbose debug information")
+		setClientName              = flag.Bool("set-client-name", getEnvBool("REDIS_EXPORTER_SET_CLIENT_NAME", true), "Whether to set client name to redis_exporter")
+		isTile38                   = flag.Bool("is-tile38", getEnvBool("REDIS_EXPORTER_IS_TILE38", false), "Whether to scrape Tile38 specific metrics")
+		isCluster                  = flag.Bool("is-cluster", getEnvBool("REDIS_EXPORTER_IS_CLUSTER", false), "Whether this is a redis cluster (Enable this if you need to fetch key level data on a Redis Cluster).")
+		exportClientList           = flag.Bool("export-client-list", getEnvBool("REDIS_EXPORTER_EXPORT_CLIENT_LIST", false), "Whether to scrape Client List specific metrics")
+		exportClientPort           = flag.Bool("export-client-port", getEnvBool("REDIS_EXPORTER_EXPORT_CLIENT_PORT", false), "Whether to include the client's port when exporting the client list. Warning: including the port increases the number of metrics generated and will make your Prometheus server take up more memory")
+		showVersion                = flag.Bool("version", false, "Show version information and exit")
+		redisMetricsOnly           = flag.Bool("redis-only-metrics", getEnvBool("REDIS_EXPORTER_REDIS_ONLY_METRICS", false), "Whether to also export go runtime metrics")
+		pingOnConnect              = flag.Bool("ping-on-connect", getEnvBool("REDIS_EXPORTER_PING_ON_CONNECT", false), "Whether to ping the redis instance after connecting")
+		inclConfigMetrics          = flag.Bool("include-config-metrics", getEnvBool("REDIS_EXPORTER_INCL_CONFIG_METRICS", false), "Whether to include all config settings as metrics")
+		includeKeysValuesAsMetrics = flag.Bool("include-keys-values-as-metrics", getEnvBool("REDIS_EXPORTER_INCL_KEYS_VALUES_METRICS", false), "Whether to include values of keys stored in redis as labels or not when using check-keys/check-single-key")
+		redactConfigMetrics        = flag.Bool("redact-config-metrics", getEnvBool("REDIS_EXPORTER_REDACT_CONFIG_METRICS", true), "Whether to redact config settings that include potentially sensitive information like passwords")
+		inclSystemMetrics          = flag.Bool("include-system-metrics", getEnvBool("REDIS_EXPORTER_INCL_SYSTEM_METRICS", false), "Whether to include system metrics like e.g. redis_total_system_memory_bytes")
+		skipTLSVerification        = flag.Bool("skip-tls-verification", getEnvBool("REDIS_EXPORTER_SKIP_TLS_VERIFICATION", false), "Whether to to skip TLS verification")
 	)
 	flag.Parse()
 
@@ -153,38 +154,39 @@ func main() {
 	exp, err := exporter.NewRedisExporter(
 		*redisAddr,
 		exporter.Options{
-			User:                  *redisUser,
-			Password:              *redisPwd,
-			PasswordMap:           passwordMap,
-			Namespace:             *namespace,
-			ConfigCommandName:     *configCommand,
-			CheckKeys:             *checkKeys,
-			CheckSingleKeys:       *checkSingleKeys,
-			CheckKeysBatchSize:    *checkKeysBatchSize,
-			CheckKeyGroups:        *checkKeyGroups,
-			MaxDistinctKeyGroups:  *maxDistinctKeyGroups,
-			CheckStreams:          *checkStreams,
-			CheckSingleStreams:    *checkSingleStreams,
-			CountKeys:             *countKeys,
-			LuaScript:             ls,
-			InclSystemMetrics:     *inclSystemMetrics,
-			InclConfigMetrics:     *inclConfigMetrics,
-			RedactConfigMetrics:   *redactConfigMetrics,
-			SetClientName:         *setClientName,
-			IsTile38:              *isTile38,
-			IsCluster:             *isCluster,
-			ExportClientList:      *exportClientList,
-			ExportClientsInclPort: *exportClientPort,
-			SkipTLSVerification:   *skipTLSVerification,
-			ClientCertFile:        *tlsClientCertFile,
-			ClientKeyFile:         *tlsClientKeyFile,
-			CaCertFile:            *tlsCaCertFile,
-			ConnectionTimeouts:    to,
-			MetricsPath:           *metricPath,
-			RedisMetricsOnly:      *redisMetricsOnly,
-			PingOnConnect:         *pingOnConnect,
-			RedisPwdFile:          *redisPwdFile,
-			Registry:              registry,
+			User:                       *redisUser,
+			Password:                   *redisPwd,
+			PasswordMap:                passwordMap,
+			Namespace:                  *namespace,
+			ConfigCommandName:          *configCommand,
+			CheckKeys:                  *checkKeys,
+			CheckSingleKeys:            *checkSingleKeys,
+			CheckKeysBatchSize:         *checkKeysBatchSize,
+			CheckKeyGroups:             *checkKeyGroups,
+			MaxDistinctKeyGroups:       *maxDistinctKeyGroups,
+			CheckStreams:               *checkStreams,
+			CheckSingleStreams:         *checkSingleStreams,
+			CountKeys:                  *countKeys,
+			LuaScript:                  ls,
+			InclSystemMetrics:          *inclSystemMetrics,
+			InclConfigMetrics:          *inclConfigMetrics,
+			IncludeKeysValuesAsMetrics: *includeKeysValuesAsMetrics,
+			RedactConfigMetrics:        *redactConfigMetrics,
+			SetClientName:              *setClientName,
+			IsTile38:                   *isTile38,
+			IsCluster:                  *isCluster,
+			ExportClientList:           *exportClientList,
+			ExportClientsInclPort:      *exportClientPort,
+			SkipTLSVerification:        *skipTLSVerification,
+			ClientCertFile:             *tlsClientCertFile,
+			ClientKeyFile:              *tlsClientKeyFile,
+			CaCertFile:                 *tlsCaCertFile,
+			ConnectionTimeouts:         to,
+			MetricsPath:                *metricPath,
+			RedisMetricsOnly:           *redisMetricsOnly,
+			PingOnConnect:              *pingOnConnect,
+			RedisPwdFile:               *redisPwdFile,
+			Registry:                   registry,
 			BuildInfo: exporter.BuildInfo{
 				Version:   BuildVersion,
 				CommitSha: BuildCommitSha,


### PR DESCRIPTION
Hi,  Thanks for this handy exporter.

I noticed that using `/scrape` and `check-keys` GET parameter, it is possible to extract keys' values allowing monitoring systems to extract actual content instead of just metrics.

It can be risky to allow accessing values of keys from monitoring systems. A secure default and an option to explicitly enable value extraction would be safer.

it is a breaking change though for people using this feature but I am not sure if keeping the insecure default would be a wise choice. wdyt?