### PR TITLE
Add metric for pubsubshard_channels

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -211,6 +211,7 @@ func NewRedisExporter(redisURI string, opts Options) (*Exporter, error) {
 			// # Stats
 			"pubsub_channels":         "pubsub_channels",
 			"pubsub_patterns":         "pubsub_patterns",
+			"pubsubshard_channels":    "pubsubshard_channels",  // Added in Redis 7.0.3
 			"latest_fork_usec":        "latest_fork_usec",
 			"tracking_total_keys":     "tracking_total_keys",
 			"tracking_total_items":    "tracking_total_items",


### PR DESCRIPTION
Adding gauge metric for `pubsubshard_channels`

> pubsubshard_channels: Global number of pub/sub shard channels with client subscriptions. Added in Redis 7.0.3