### PR TITLE
Add support for loading TLS system certificate store

### DIFF
--- a/exporter/tls.go
+++ b/exporter/tls.go
@@ -29,6 +29,14 @@ func (e *Exporter) CreateClientTLSConfig() (*tls.Config, error) {
 			return nil, err
 		}
 		tlsConfig.RootCAs = certificates
+	} else {
+		// Load the system certificate pool
+		rootCAs, err := x509.SystemCertPool()
+		if err != nil {
+			return nil, err
+		}
+
+		tlsConfig.RootCAs = rootCAs
 	}
 
 	return &tlsConfig, nil

--- a/exporter/tls_test.go
+++ b/exporter/tls_test.go
@@ -19,6 +19,7 @@ func TestCreateClientTLSConfig(t *testing.T) {
 			ClientKeyFile:  "../contrib/tls/redis.key"}, true},
 		{"load_ca_cert", Options{
 			CaCertFile: "../contrib/tls/ca.crt"}, true},
+		{"load_system_certs", Options{}, true},
 
 		// negative tests
 		{"nonexisting_client_files", Options{


### PR DESCRIPTION
Previously a server CA had to be specified for TLS work, even if the system store trusted the cert already.