### PR TITLE
fix scrapping for redis < 4.0

### DIFF
--- a/exporter/key_groups.go
+++ b/exporter/key_groups.go
@@ -173,7 +173,10 @@ for i=3,#ARGV do
   end
 end
 for i,key in ipairs(batch[2]) do
-  usage = redis.call("MEMORY", "USAGE", key)
+  local reply = redis.pcall("MEMORY", "USAGE", key)  
+  if reply['err'] == nil then
+    usage = reply;
+  end
   group = nil
   for i=3,#ARGV do
     key_match_result = {string.find(key, ARGV[i])}

--- a/exporter/key_groups.go
+++ b/exporter/key_groups.go
@@ -174,7 +174,7 @@ for i=3,#ARGV do
 end
 for i,key in ipairs(batch[2]) do
   local reply = redis.pcall("MEMORY", "USAGE", key)  
-  if reply['err'] == nil then
+  if type(reply) == "number" then
     usage = reply;
   end
   group = nil


### PR DESCRIPTION
This fix avoid an exception to bee thrown so scrapping fail for redis version < 4.0
Metrics will so only contains keys_group_count and not memory_usage 
Tested on docker redis 3.2.4: (docker pull r900/redis:3.2.4)
