### PR TITLE
Add password key option

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -78,6 +78,7 @@ type Options struct {
 	RedisMetricsOnly          bool
 	PingOnConnect             bool
 	RedisPwdFile              string
+	RedisPwdKey               string
 	Registry                  *prometheus.Registry
 	BuildInfo                 BuildInfo
 }
@@ -189,10 +190,10 @@ func NewRedisExporter(redisURI string, opts Options) (*Exporter, error) {
 			"rdb_last_bgsave_status":       "rdb_last_bgsave_status",
 			"rdb_last_bgsave_time_sec":     "rdb_last_bgsave_duration_sec",
 			"rdb_current_bgsave_time_sec":  "rdb_current_bgsave_duration_sec",
-                        "rdb_saves":                    "rdb_saves_total",
+			"rdb_saves":                    "rdb_saves_total",
 			"rdb_last_cow_size":            "rdb_last_cow_size_bytes",
-                        "rdb_last_load_keys_expired":   "rdb_last_load_expired_keys",
-                        "rdb_last_load_keys_loaded":    "rdb_last_load_loaded_keys",
+			"rdb_last_load_keys_expired":   "rdb_last_load_expired_keys",
+			"rdb_last_load_keys_loaded":    "rdb_last_load_loaded_keys",
 			"aof_enabled":                  "aof_enabled",
 			"aof_rewrite_in_progress":      "aof_rewrite_in_progress",
 			"aof_rewrite_scheduled":        "aof_rewrite_scheduled",

--- a/exporter/http.go
+++ b/exporter/http.go
@@ -77,6 +77,7 @@ func (e *Exporter) scrapeHandler(w http.ResponseWriter, r *http.Request) {
 
 	registry := prometheus.NewRegistry()
 	opts.Registry = registry
+	opts.RedisPwdKey = r.URL.Query().Get(e.options.RedisPwdKey)
 
 	_, err = NewRedisExporter(target, opts)
 	if err != nil {

--- a/exporter/redis.go
+++ b/exporter/redis.go
@@ -36,6 +36,12 @@ func (e *Exporter) configureOptions(uri string) ([]redis.DialOption, error) {
 		options = append(options, redis.DialPassword(e.options.PasswordMap[uri]))
 	}
 
+	if pwdKey := e.options.RedisPwdKey; pwdKey != "" {
+		if p := e.options.PasswordMap[pwdKey]; p != "" {
+			options = append(options, redis.DialPassword(p))
+		}
+	}
+
 	return options, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ func main() {
 		redisUser                 = flag.String("redis.user", getEnv("REDIS_USER", ""), "User name to use for authentication (Redis ACL for Redis 6.0 and newer)")
 		redisPwd                  = flag.String("redis.password", getEnv("REDIS_PASSWORD", ""), "Password of the Redis instance to scrape")
 		redisPwdFile              = flag.String("redis.password-file", getEnv("REDIS_PASSWORD_FILE", ""), "Password file of the Redis instance to scrape")
+		redisPwdKey               = flag.String("redis.password-key", getEnv("REDIS_PASSWORD_KEY", ""), "Password Key of the password contained in password-file")
 		namespace                 = flag.String("namespace", getEnv("REDIS_EXPORTER_NAMESPACE", "redis"), "Namespace for metrics")
 		checkKeys                 = flag.String("check-keys", getEnv("REDIS_EXPORTER_CHECK_KEYS", ""), "Comma separated list of key-patterns to export value and length/size, searched for with SCAN")
 		checkSingleKeys           = flag.String("check-single-keys", getEnv("REDIS_EXPORTER_CHECK_SINGLE_KEYS", ""), "Comma separated list of single keys to export value and length/size")
@@ -189,6 +190,7 @@ func main() {
 			RedisMetricsOnly:          *redisMetricsOnly,
 			PingOnConnect:             *pingOnConnect,
 			RedisPwdFile:              *redisPwdFile,
+			RedisPwdKey:               *redisPwdKey,
 			Registry:                  registry,
 			BuildInfo: exporter.BuildInfo{
 				Version:   BuildVersion,


### PR DESCRIPTION
The Redis does not support auth by username and password until version 6.0. So in legacy version instances, administrator can only set one password.

The current version of redis_exporter support read password from the path specified by the password-file option according to the URI of redis connection to collect metrics from multiple targets.

But this design requires the administrator list all target URIs into the password file. Every time new instance created, the password file has to be updated. Besides, having many different instances dose not necessarily require all of them use different passwords. They may be separated into several groups, and instances of the same group may use identical password.

In this scenario, it will be more convenient to introduce the concept of password key. When the collecting job fetch the probe API, it can transport one additional key for password:

```
http://10.0.0.1:9121/scrape?target=foo:6379&passkey=dev
http://10.0.0.1:9121/scrape?target=bar:6379&passkey=dev
```

Both the instances of foo:6379 and bar:6379 could use the same password, and we can only add one line into the password file:

```
dev:dev-pass
```