### PR TITLE
Support Docker Compose V2 in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .DEFAULT_GOAL := build
 
+DOCKER_COMPOSE := $(if $(shell which docker-compose),docker-compose,docker compose)
+
 .PHONY: build
 build:
 	go build .
@@ -11,18 +13,18 @@ docker-all: docker-env-up docker-test docker-env-down
 
 .PHONY: docker-env-up
 docker-env-up:
-	docker-compose -f contrib/docker-compose-for-tests.yml up -d
+	$(DOCKER_COMPOSE) -f contrib/docker-compose-for-tests.yml up -d
 
 
 .PHONY: docker-env-down
 docker-env-down:
-	docker-compose -f contrib/docker-compose-for-tests.yml down
+	$(DOCKER_COMPOSE) -f contrib/docker-compose-for-tests.yml down
 
 
 .PHONY: docker-test
 docker-test:
-	docker-compose -f contrib/docker-compose-for-tests.yml up -d
-	docker-compose -f contrib/docker-compose-for-tests.yml run --rm tests bash -c 'make test'
+	$(DOCKER_COMPOSE) -f contrib/docker-compose-for-tests.yml up -d
+	$(DOCKER_COMPOSE) -f contrib/docker-compose-for-tests.yml run --rm tests bash -c 'make test'
 
 
 


### PR DESCRIPTION
Since Docker Compose is installed as a plugin in v2 the binary `docker-compose` is not always available.
The makefile will now use `docker compose` in that case.

The [recommendation](https://docs.docker.com/compose/migrate/#docker-compose-vs-docker-compose) is to start using the command `docker compose` instead of `docker-compose`, so an alternative is to replace, but this gives somewhat smoother migration.
