### PR TITLE
fix: compatible with stream entry id metric for redis version 6.x/5.x.

### DIFF
--- a/exporter/streams.go
+++ b/exporter/streams.go
@@ -52,8 +52,18 @@ func getStreamInfo(c redis.Conn, key string) (*streamInfo, error) {
 	}
 
 	// Extract first and last id from slice
-	stream.FirstEntryId = getStreamEntryId(values, 17)
-	stream.LastEntryId = getStreamEntryId(values, 19)
+	for idx, v := range values {
+		vbytes, ok := v.([]byte)
+		if !ok {
+			continue
+		}
+		if strings.EqualFold(string(vbytes), "first-entry") {
+			stream.FirstEntryId = getStreamEntryId(values, idx+1)
+		}
+		if strings.EqualFold(string(vbytes), "last-entry") {
+			stream.LastEntryId = getStreamEntryId(values, idx+1)
+		}
+	}
 
 	stream.StreamGroupsInfo, err = scanStreamGroups(c, key)
 	if err != nil {

--- a/exporter/streams.go
+++ b/exporter/streams.go
@@ -57,10 +57,10 @@ func getStreamInfo(c redis.Conn, key string) (*streamInfo, error) {
 		if !ok {
 			continue
 		}
-		if strings.EqualFold(string(vbytes), "first-entry") {
+		if string(vbytes) == "first-entry" {
 			stream.FirstEntryId = getStreamEntryId(values, idx+1)
 		}
-		if strings.EqualFold(string(vbytes), "last-entry") {
+		if string(vbytes) == "last-entry" {
 			stream.LastEntryId = getStreamEntryId(values, idx+1)
 		}
 	}
@@ -75,9 +75,12 @@ func getStreamInfo(c redis.Conn, key string) (*streamInfo, error) {
 }
 
 func getStreamEntryId(redisValue []interface{}, index int) string {
-	if _, ok := redisValue[index].([]interface{}); !ok ||
-		len(redisValue) < index || redisValue[index] == nil ||
-		len(redisValue[index].([]interface{})) < 2 {
+	if values, ok := redisValue[index].([]interface{}); !ok || len(values) < 2 {
+		log.Debugf("Failed to parse StreamEntryId")
+		return ""
+	}
+
+	if len(redisValue) < index || redisValue[index] == nil {
 		log.Debugf("Failed to parse StreamEntryId")
 		return ""
 	}

--- a/exporter/streams.go
+++ b/exporter/streams.go
@@ -75,7 +75,9 @@ func getStreamInfo(c redis.Conn, key string) (*streamInfo, error) {
 }
 
 func getStreamEntryId(redisValue []interface{}, index int) string {
-	if len(redisValue) < index || redisValue[index] == nil || len(redisValue[index].([]interface{})) < 2 {
+	if _, ok := redisValue[index].([]interface{}); !ok ||
+		len(redisValue) < index || redisValue[index] == nil ||
+		len(redisValue[index].([]interface{})) < 2 {
 		log.Debugf("Failed to parse StreamEntryId")
 		return ""
 	}

--- a/exporter/streams_test.go
+++ b/exporter/streams_test.go
@@ -88,11 +88,11 @@ func TestStreamsGetStreamInfo(t *testing.T) {
 			if isNotTestTimestamp(info.LastGeneratedId) {
 				t.Errorf("Stream LastGeneratedId mismatch.\nActual: %#v;\nExpected any of: %#v", info.LastGeneratedId, TestStreamTimestamps)
 			}
-			if info.FirstEntryId != "" {
-				t.Errorf("Stream FirstEntryId mismatch.\nActual: %#v; - Expected empty", info.FirstEntryId)
+			if info.FirstEntryId != TestStreamTimestamps[0] {
+				t.Errorf("Stream FirstEntryId mismatch.\nActual: %#v;\nExpected any of: %#v", info.FirstEntryId, TestStreamTimestamps)
 			}
-			if info.LastEntryId != "" {
-				t.Errorf("Stream LastEntryId mismatch.\nActual: %#v;\nExpected empty", info.LastEntryId)
+			if info.LastEntryId != TestStreamTimestamps[len(TestStreamTimestamps)-1] {
+				t.Errorf("Stream LastEntryId mismatch.\nActual: %#v;\nExpected any of: %#v", info.LastEntryId, TestStreamTimestamps)
 			}
 			if info.MaxDeletedEntryId != "" {
 				t.Errorf("Stream MaxDeletedEntryId mismatch.\nActual: %#v;\nExpected: %#v", info.MaxDeletedEntryId, "0-0")


### PR DESCRIPTION
The entry id in different versions of redis is not always in the 17th and 19th positions of the `xinfo stream`.

In 6.x and 5.x, `first-entry` is 11th, `last-entry` is 13th