### PR TITLE
Bump alpine to 3.20.1 to fix CVEs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,7 +36,7 @@ ENTRYPOINT [ "/redis_exporter" ]
 #
 # Alpine release container
 #
-FROM --platform=linux/$GOARCH alpine:3.20.1 as alpine
+FROM --platform=linux/$GOARCH alpine:3.20 as alpine
 
 COPY --from=builder /redis_exporter /redis_exporter
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,7 +36,7 @@ ENTRYPOINT [ "/redis_exporter" ]
 #
 # Alpine release container
 #
-FROM --platform=linux/$GOARCH alpine:3.20.0 as alpine
+FROM --platform=linux/$GOARCH alpine:3.20.1 as alpine
 
 COPY --from=builder /redis_exporter /redis_exporter
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs


### PR DESCRIPTION
resolves CVE-2023-42365 found in

alpine://3.20:busybox-binsh:1.36.1-r28
alpine://3.20:ssl_client:1.36.1-r28
alpine://3.20:busybox:1.36.1-r28

























































