### PR TITLE
feat: add label `master_replid` to metric`instance_info`

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -363,7 +363,7 @@ func NewRedisExporter(redisURI string, opts Options) (*Exporter, error) {
 		"db_keys_cached":                                  {txt: "Total number of cached keys by DB", lbls: []string{"db"}},
 		"errors_total":                                    {txt: `Total number of errors per error type`, lbls: []string{"err"}},
 		"exporter_last_scrape_error":                      {txt: "The last scrape error status.", lbls: []string{"err"}},
-		"instance_info":                                   {txt: "Information about the Redis instance", lbls: []string{"role", "redis_version", "redis_build_id", "redis_mode", "os", "maxmemory_policy", "tcp_port", "run_id", "process_id"}},
+		"instance_info":                                   {txt: "Information about the Redis instance", lbls: []string{"role", "redis_version", "redis_build_id", "redis_mode", "os", "maxmemory_policy", "tcp_port", "run_id", "process_id", "master_replid"}},
 		"key_group_count":                                 {txt: `Count of keys in key group`, lbls: []string{"db", "key_group"}},
 		"key_group_memory_usage_bytes":                    {txt: `Total memory usage of key group in bytes`, lbls: []string{"db", "key_group"}},
 		"key_size":                                        {txt: `The length or size of "key"`, lbls: []string{"db", "key"}},

--- a/exporter/info.go
+++ b/exporter/info.go
@@ -168,7 +168,10 @@ func (e *Exporter) extractInfoMetrics(ch chan<- prometheus.Metric, info string, 
 		keyValues["redis_mode"],
 		keyValues["os"],
 		keyValues["maxmemory_policy"],
-		keyValues["tcp_port"], keyValues["run_id"], keyValues["process_id"],
+		keyValues["tcp_port"],
+		keyValues["run_id"],
+		keyValues["process_id"],
+		keyValues["master_replid"],
 	)
 
 	if keyValues["role"] == "slave" {


### PR DESCRIPTION
metrics output
```
redis_instance_info{master_replid="08d93f3f012d5c31fc135f81eebe34056a16718b",maxmemory_policy="noeviction",os="Linux 6.8.11-300.fc40.aarch64 aarch64",process_id="1",redis_build_id="f52510608ef57ee1",redis_mode="standalone",redis_version="6.2.6",role="master",run_id="5df26f6efeab16c5eed4f8198f431559f510ccfc",tcp_port="6379"} 1
```
related issue: #919 

only add label `master_replid` to metric`instance_info`, replication metrics hasn't add this label. Will add later