### PR TITLE
fix: stop return metrics when parse float value err

### DIFF
--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -59,6 +59,7 @@ func (e *Exporter) parseAndRegisterConstMetric(ch chan<- prometheus.Metric, fiel
 	}
 	if err != nil {
 		log.Debugf("couldn't parse %s, err: %s", fieldValue, err)
+		return
 	}
 
 	t := prometheus.GaugeValue


### PR DESCRIPTION
if parse value err, means the value is not float. So there may be something bad happened. If we dont't return, the metric value is 0, which may has a different meaning with the real value. From the code above, `0` also means `fail`, `err` and `false`.