### PR TITLE
Feature: two config ways both work

### DIFF
--- a/exporter/redis.go
+++ b/exporter/redis.go
@@ -24,15 +24,12 @@ func (e *Exporter) configureOptions(uri string) ([]redis.DialOption, error) {
 		redis.DialUseTLS(strings.HasPrefix(e.redisAddr, "rediss://")),
 	}
 
-	if e.options.User != "" {
-		options = append(options, redis.DialUsername(e.options.User))
-	}
-
-	if e.options.Password != "" {
+	if e.options.Password != "" && e.options.PasswordMap[uri] != "" {
+		options = append(options, redis.DialPassword(e.options.PasswordMap[uri]))
+	} else if e.options.Password != "" && e.options.User != "" {
 		options = append(options, redis.DialPassword(e.options.Password))
-	}
-
-	if e.options.PasswordMap[uri] != "" {
+		options = append(options, redis.DialUsername(e.options.User))
+	} else if e.options.PasswordMap[uri] != "" {
 		options = append(options, redis.DialPassword(e.options.PasswordMap[uri]))
 	}
 

--- a/main.go
+++ b/main.go
@@ -133,7 +133,7 @@ func main() {
 	}
 
 	passwordMap := make(map[string]string)
-	if *redisPwd == "" && *redisPwdFile != "" {
+	if *redisPwdFile != "" {
 		passwordMap, err = exporter.LoadPwdFile(*redisPwdFile)
 		if err != nil {
 			log.Fatalf("Error loading redis passwords from file %s, err: %s", *redisPwdFile, err)


### PR DESCRIPTION
I want to use a `redis_exporter` to monitor multiple versions of Redis. I typically use non-default users with `-redis.user=exporter `and `-redis.password`. However, for Redis versions lower than 6.0, only the default user can be used. Therefore, I am submitting this request: for lower versions of Redis, please allow the use of `--redis.password-file`, while for other versions, I would like to continue using -redis.user=exporter and -redis.password. the both config ways all work.
example: `./redis_exporter -redis.user=exporter -redis.password=xxx --redis.password-file=./passwd.json`