### PR TITLE
Make the grafana dashboard provisionable

### DIFF
--- a/contrib/grafana_prometheus_redis_dashboard.json
+++ b/contrib/grafana_prometheus_redis_dashboard.json
@@ -1544,6 +1544,24 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "datasource",
+        "multi": false,
+        "name": "DS_PROM",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "current": {},
         "datasource": {
           "type": "prometheus",


### PR DESCRIPTION
Add a datasource variable into the grafana dashboard template. This makes the dashboard suitable for provisioning.

[More info about dashboard provisioning](https://grafana.com/docs/grafana/latest/administration/provisioning/#dashboards)