### PR TITLE
Support docker buildx for multiple platforms building.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,26 +1,27 @@
-ARG GOARCH
 #
 # build container
 #
-FROM --platform=linux/amd64 golang:1.22-alpine as builder
+FROM --platform=$BUILDPLATFORM golang:1.22-alpine AS builder
 WORKDIR /go/src/github.com/oliver006/redis_exporter/
 
 ADD . /go/src/github.com/oliver006/redis_exporter/
 
 ARG SHA1="[no-sha]"
 ARG TAG="[no-tag]"
-ARG GOARCH
+ARG TARGETARCH
+ARG GOARCH=$TARGETARCH
 
-RUN printf "nameserver 1.1.1.1\nnameserver 8.8.8.8"> /etc/resolv.conf \ && apk --no-cache add ca-certificates git
+# RUN printf "nameserver 1.1.1.1\nnameserver 8.8.8.8"> /etc/resolv.conf \ && apk --no-cache add ca-certificates git
+RUN apk --no-cache add ca-certificates git
 RUN BUILD_DATE=$(date +%F-%T) CGO_ENABLED=0 GOOS=linux GOARCH=$GOARCH go build -o /redis_exporter \
     -ldflags  "-s -w -extldflags \"-static\" -X main.BuildVersion=$TAG -X main.BuildCommitSha=$SHA1 -X main.BuildDate=$BUILD_DATE" .
 
-RUN [ "$GOARCH" = "amd64" ]  && /redis_exporter -version || ls -la /redis_exporter
+RUN [ "$GOARCH" = $GOARCH ]  && /redis_exporter -version || ls -la /redis_exporter
 
 #
 # scratch release container
 #
-FROM --platform=linux/$GOARCH scratch as scratch
+FROM scratch AS scratch
 
 COPY --from=builder /redis_exporter /redis_exporter
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
@@ -36,7 +37,7 @@ ENTRYPOINT [ "/redis_exporter" ]
 #
 # Alpine release container
 #
-FROM --platform=linux/$GOARCH alpine:3.20 as alpine
+FROM alpine:3.20 AS alpine
 
 COPY --from=builder /redis_exporter /redis_exporter
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs


### PR DESCRIPTION
e.g.

```
docker buildx build \
  --push \
  --platform linux/amd64,linux/arm64 \
  -f ./docker/Dockerfile \
  -t oliver006/redis_exporter:v1.6.2 \
  ./
```