### PR TITLE
Hotfix: Fix search_total_indexing_time metric type

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -284,11 +284,9 @@ func NewRedisExporter(redisURI string, opts Options) (*Exporter, error) {
 			"long_lock_waits":       "long_lock_waits_total",
 			"current_client_thread": "current_client_thread",
 
-			// Redis Modules metrics
-			// RediSearch module
+			// Redis Modules metrics, RediSearch module
 			"search_number_of_indexes":   "search_number_of_indexes",
 			"search_used_memory_indexes": "search_used_memory_indexes_bytes",
-			"search_total_indexing_time": "search_total_indexing_time_ms",
 			"search_global_idle":         "search_global_idle",
 			"search_global_total":        "search_global_total",
 			"search_bytes_collected":     "search_collected_bytes",
@@ -349,6 +347,9 @@ func NewRedisExporter(redisURI string, opts Options) (*Exporter, error) {
 			"cached_keys":                  "cached_keys_total",
 			"storage_provider_read_hits":   "storage_provider_read_hits",
 			"storage_provider_read_misses": "storage_provider_read_misses",
+
+			// Redis Modules metrics, RediSearch module
+			"search_total_indexing_time": "search_indexing_time_ms_total",
 		},
 	}
 

--- a/exporter/modules_test.go
+++ b/exporter/modules_test.go
@@ -37,7 +37,7 @@ func TestModules(t *testing.T) {
 			"module_info":                      false,
 			"search_number_of_indexes":         false,
 			"search_used_memory_indexes_bytes": false,
-			"search_total_indexing_time_ms":    false,
+			"search_indexing_time_ms_total":    false,
 			"search_global_idle":               false,
 			"search_global_total":              false,
 			"search_collected_bytes":           false,


### PR DESCRIPTION
According to my tests with real workload, this metric type is counter, I'm renaming it according to Prometheus recommendations and moving to `metricMapCounters` map.