### PR TITLE
maxclients extracted info all

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -134,6 +134,7 @@ func NewRedisExporter(uri string, opts Options) (*Exporter, error) {
 			// # Clients
 			"connected_clients":            "connected_clients",
 			"blocked_clients":              "blocked_clients",
+			"maxclients":                   "max_clients",
 			"tracking_clients":             "tracking_clients",
 			"clients_in_timeout_table":     "clients_in_timeout_table",
 			"pubsub_clients":               "pubsub_clients",               // Added in Redis 7.4


### PR DESCRIPTION
GCP Redis does not support the config command, making it impossible to retrieve maxclients. It needs to be extracted from info all