### PR TITLE
add ignoreEmptyDatabases for ignore empty database redis_db_keys* metric

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -84,6 +84,7 @@ type Options struct {
 	BuildInfo                      BuildInfo
 	BasicAuthUsername              string
 	BasicAuthPassword              string
+	IgnoreEmptyDatabases           bool
 }
 
 // NewRedisExporter returns a new exporter of Redis metrics.

--- a/exporter/info.go
+++ b/exporter/info.go
@@ -153,11 +153,13 @@ func (e *Exporter) extractInfoMetrics(ch chan<- prometheus.Metric, info string, 
 	// from #Commandstats processing and the percentile info that we get from the #Latencystats processing
 	e.generateCommandLatencySummaries(ch, cmdLatencyMap, cmdCount, cmdSum)
 
-	for dbIndex := 0; dbIndex < dbCount; dbIndex++ {
-		dbName := "db" + strconv.Itoa(dbIndex)
-		if _, exists := handledDBs[dbName]; !exists {
-			e.registerConstMetricGauge(ch, "db_keys", 0, dbName)
-			e.registerConstMetricGauge(ch, "db_keys_expiring", 0, dbName)
+	if !e.options.IgnoreEmptyDatabases {
+		for dbIndex := 0; dbIndex < dbCount; dbIndex++ {
+			dbName := "db" + strconv.Itoa(dbIndex)
+			if _, exists := handledDBs[dbName]; !exists {
+				e.registerConstMetricGauge(ch, "db_keys", 0, dbName)
+				e.registerConstMetricGauge(ch, "db_keys_expiring", 0, dbName)
+			}
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -102,6 +102,7 @@ func main() {
 		skipTLSVerification            = flag.Bool("skip-tls-verification", getEnvBool("REDIS_EXPORTER_SKIP_TLS_VERIFICATION", false), "Whether to to skip TLS verification")
 		basicAuthUsername              = flag.String("basic-auth-username", getEnv("REDIS_EXPORTER_BASIC_AUTH_USERNAME", ""), "Username for basic authentication")
 		basicAuthPassword              = flag.String("basic-auth-password", getEnv("REDIS_EXPORTER_BASIC_AUTH_PASSWORD", ""), "Password for basic authentication")
+		ignoreEmptyDatabases           = flag.Bool("ignore-empty-databases", getEnvBool("REDIS_EXPORTER_IGNORE_EMPTY_DATABASES", false), "Whether to ignore databases metric")
 	)
 	flag.Parse()
 
@@ -203,8 +204,9 @@ func main() {
 				CommitSha: BuildCommitSha,
 				Date:      BuildDate,
 			},
-			BasicAuthUsername: *basicAuthUsername,
-			BasicAuthPassword: *basicAuthPassword,
+			BasicAuthUsername:    *basicAuthUsername,
+			BasicAuthPassword:    *basicAuthPassword,
+			IgnoreEmptyDatabases: *ignoreEmptyDatabases,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
I use redis for dev, single redis instance has 100000 databases, but 99% empty
so i add a IgnoreEmptyDatabases for ignore all empty databases metrics (db_keys, db_keys_expiring)

I am not a developer, i just edit code do what i want and put code here. maybe someone need this