### PR TITLE
fix(exporter): improve error message in HTTP handler

### DIFF
--- a/exporter/http.go
+++ b/exporter/http.go
@@ -94,7 +94,7 @@ func (e *Exporter) scrapeHandler(w http.ResponseWriter, r *http.Request) {
 
 	_, err = NewRedisExporter(target, opts)
 	if err != nil {
-		http.Error(w, "NewRedisExporter() err: err", http.StatusBadRequest)
+		http.Error(w, fmt.Sprintf("NewRedisExporter() error: %v", err), http.StatusBadRequest)
 		e.targetScrapeRequestErrors.Inc()
 		return
 	}


### PR DESCRIPTION
Previously, the error message for RedisExporter initialization was hardcoded and didn't include the actual error details. This commit modifies the error response to include the dynamic error value using fmt.Sprintf(), making debugging easier.