### PR TITLE
Chore: Remove v0.3 from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,11 +10,6 @@ assignees: oliver006
 **Describe the problem**
 A clear and concise description of what the bug is.
 
-**What version of redis_exporter are you running?**
-Please run `redis_exporter --version` if you're not sure what version you're running.
-[ ] 0.3x.x
-[ ] 1.x.x
-
 
 **Running the exporter**
 What's the full command you're using to run the exporter? (please remove passwords and other sensitive data)

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -10,11 +10,6 @@ assignees: oliver006
 **Describe the problem**
 A clear and concise description of what the question is.
 
-**What version of redis_exporter are you running?**
-Please run `redis_exporter --version` if you're not sure what version you're running.
-[ ] 0.3x.x
-[ ] 1.x.x
-
 
 **Running the exporter**
 What's the full command you're using to run the exporter? (please remove passwords and other sensitive data)


### PR DESCRIPTION
As discussed in https://github.com/oliver006/redis_exporter/issues/1034#issuecomment-3238700099

v1.x was released in 2019 https://github.com/oliver006/redis_exporter/releases/tag/v1.0.0