### PR TITLE
remove bitname redis-cluster image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ test:
 	TEST_USER_PWD_REDIS_URI="redis://exporter:exporter-password@localhost:16390" \
 	TEST_REDIS_CLUSTER_MASTER_URI="redis://localhost:17000" \
 	TEST_REDIS_CLUSTER_SLAVE_URI="redis://localhost:17005" \
-	TEST_REDIS_CLUSTER_PASSWORD_URI="redis://localhost:17006" \
+	TEST_VALKEY_CLUSTER_PASSWORD_URI="redis://localhost:17006" \
 	TEST_TILE38_URI="redis://localhost:19851" \
 	TEST_REDIS_SENTINEL_URI="redis://localhost:26379" \
 	TEST_REDIS_MODULES_URI="redis://localhost:36379" \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,20 +94,19 @@ services:
       - "16402:6379"
 
   valkey-cluster:
-    image: oliver006/valkey-cluster:8.1.1
+    image: oliver006/valkey-cluster:8.1.3
     environment:
       - IP=0.0.0.0
     ports:
       - 7000-7005:7000-7005
       - 17000-17005:7000-7005
 
-  redis-cluster-password:
-    image: bitnami/redis-cluster:7.4
+  valkey-cluster-password:
+    image: oliver006/valkey-cluster:8.1.3
     environment:
-      - REDIS_PORT_NUMBER=7006
-      - REDIS_PASSWORD=redis-password
-      - REDIS_CLUSTER_CREATOR=yes
-      - REDIS_NODES=redis-cluster-password:7006
+      - IP=0.0.0.0
+      - INITIAL_PORT=7006
+      - VALKEY_PASSWORD=redis-password
     ports:
       - "17006:7006"
 

--- a/exporter/redis_test.go
+++ b/exporter/redis_test.go
@@ -117,9 +117,9 @@ func TestPasswordInvalid(t *testing.T) {
 }
 
 func TestConnectToClusterUsingPasswordFile(t *testing.T) {
-	clusterUri := os.Getenv("TEST_REDIS_CLUSTER_PASSWORD_URI")
+	clusterUri := os.Getenv("TEST_VALKEY_CLUSTER_PASSWORD_URI")
 	if clusterUri == "" {
-		t.Skipf("TEST_REDIS_CLUSTER_PASSWORD_URI is not set")
+		t.Skipf("TEST_VALKEY_CLUSTER_PASSWORD_URI is not set")
 	}
 	passMap := map[string]string{clusterUri: "redis-password"}
 	wrongPassMap := map[string]string{"redis://redis-cluster-password-wrong:7006": "redis-password"}


### PR DESCRIPTION
remove bitname redis-cluster image, use oliver006/ valkey-cluster-password instead


bitnami is planning to remove their docker images or make them for-pay

see: 
https://community.broadcom.com/tanzu/blogs/beltran-rueda-borrego/2025/08/18/how-to-prepare-for-the-bitnami-changes-coming-soon

one down, one to go