### PR TITLE
replace bitnami/valkey-sentinel docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ test:
 	TEST_REDIS_CLUSTER_SLAVE_URI="redis://localhost:17005" \
 	TEST_VALKEY_CLUSTER_PASSWORD_URI="redis://localhost:17006" \
 	TEST_TILE38_URI="redis://localhost:19851" \
-	TEST_REDIS_SENTINEL_URI="redis://localhost:26379" \
+	TEST_VALKEY_SENTINEL_URI="redis://localhost:26379" \
 	TEST_REDIS_MODULES_URI="redis://localhost:36379" \
 	go test -v -covermode=atomic -cover -race -coverprofile=coverage.txt -p 1 ./...
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,12 +110,21 @@ services:
     ports:
       - "17006:7006"
 
-  redis-sentinel:
-    image: docker.io/bitnami/redis-sentinel:6.2-debian-10
-    environment:
-      - REDIS_MASTER_HOST=redis6
+
+  valkey-sentinel:
+    image: valkey/valkey:8
+    depends_on:
+      - valkey8
     ports:
       - "26379:26379"
+    command: >
+      sh -c 'echo "sentinel resolve-hostnames yes" > /etc/sentinel.conf &&
+            echo "sentinel monitor mymaster valkey8 6379 1" >> /etc/sentinel.conf &&
+            echo "sentinel down-after-milliseconds mymaster 1000" >> /etc/sentinel.conf &&
+            echo "sentinel failover-timeout mymaster 5000" >> /etc/sentinel.conf &&
+            echo "sentinel parallel-syncs mymaster 1" >> /etc/sentinel.conf &&
+            valkey-server /etc/sentinel.conf --sentinel'
+
 
   tile38:
     image: tile38/tile38:latest

--- a/exporter/sentinels_test.go
+++ b/exporter/sentinels_test.go
@@ -12,10 +12,10 @@ import (
 )
 
 func TestSentinelExtractInfoMetrics(t *testing.T) {
-	if os.Getenv("TEST_REDIS_SENTINEL_URI") == "" {
-		t.Skipf("TEST_REDIS_SENTINEL_URI not set - skipping")
+	if os.Getenv("TEST_VALKEY_SENTINEL_URI") == "" {
+		t.Skipf("TEST_VALKEY_SENTINEL_URI not set - skipping")
 	}
-	addr := os.Getenv("TEST_REDIS_SENTINEL_URI")
+	addr := os.Getenv("TEST_VALKEY_SENTINEL_URI")
 	e, _ := NewRedisExporter(
 		addr,
 		Options{Namespace: "test"},
@@ -140,10 +140,10 @@ func TestSentinelExtractSentinelMetricsForRedis(t *testing.T) {
 }
 
 func TestSentinelExtractSentinelMetricsForSentinel(t *testing.T) {
-	if os.Getenv("TEST_REDIS_SENTINEL_URI") == "" {
-		t.Skipf("TEST_REDIS_SENTINEL_URI not set - skipping")
+	if os.Getenv("TEST_VALKEY_SENTINEL_URI") == "" {
+		t.Skipf("TEST_VALKEY_SENTINEL_URI not set - skipping")
 	}
-	addr := os.Getenv("TEST_REDIS_SENTINEL_URI")
+	addr := os.Getenv("TEST_VALKEY_SENTINEL_URI")
 	e, _ := NewRedisExporter(
 		addr,
 		Options{Namespace: "test"},
@@ -205,10 +205,10 @@ type sentinelSentinelsData struct {
 }
 
 func TestSentinelProcessSentinels(t *testing.T) {
-	if os.Getenv("TEST_REDIS_SENTINEL_URI") == "" {
-		t.Skipf("TEST_REDIS_SENTINEL_URI not set - skipping")
+	if os.Getenv("TEST_VALKEY_SENTINEL_URI") == "" {
+		t.Skipf("TEST_VALKEY_SENTINEL_URI not set - skipping")
 	}
-	addr := os.Getenv("TEST_REDIS_SENTINEL_URI")
+	addr := os.Getenv("TEST_VALKEY_SENTINEL_URI")
 	e, _ := NewRedisExporter(
 		addr,
 		Options{Namespace: "test"},
@@ -269,10 +269,10 @@ type sentinelSlavesData struct {
 }
 
 func TestSentinelProcessSlaves(t *testing.T) {
-	if os.Getenv("TEST_REDIS_SENTINEL_URI") == "" {
-		t.Skipf("TEST_REDIS_SENTINEL_URI not set - skipping")
+	if os.Getenv("TEST_VALKEY_SENTINEL_URI") == "" {
+		t.Skipf("TEST_VALKEY_SENTINEL_URI not set - skipping")
 	}
-	addr := os.Getenv("TEST_REDIS_SENTINEL_URI")
+	addr := os.Getenv("TEST_VALKEY_SENTINEL_URI")
 	e, _ := NewRedisExporter(
 		addr,
 		Options{Namespace: "test"},
@@ -329,10 +329,10 @@ func TestSentinelProcessSlaves(t *testing.T) {
 }
 
 func TestSentinelScrapeRedisHostSentinelPath(t *testing.T) {
-	if os.Getenv("TEST_REDIS_SENTINEL_URI") == "" {
-		t.Skipf("TEST_REDIS_SENTINEL_URI not set - skipping")
+	if os.Getenv("TEST_VALKEY_SENTINEL_URI") == "" {
+		t.Skipf("TEST_VALKEY_SENTINEL_URI not set - skipping")
 	}
-	addr := os.Getenv("TEST_REDIS_SENTINEL_URI")
+	addr := os.Getenv("TEST_VALKEY_SENTINEL_URI")
 	e, _ := NewRedisExporter(
 		addr,
 		Options{Namespace: "test"},


### PR DESCRIPTION
remove bitname redis-sentinel image, use vanilla valkey image instead

bitnami is planning to remove their docker images or make them for-pay

see:
https://community.broadcom.com/tanzu/blogs/beltran-rueda-borrego/2025/08/18/how-to-prepare-for-the-bitnami-changes-coming-soon

