### PR TITLE
feat: Improve cluster node discovery with TLS and auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,8 @@ test:
 	TEST_REDIS88_CLUSTER_MASTER_URI="redis://localhost:47000" \
 	TEST_REDIS_CLUSTER_SLAVE_URI="redis://localhost:17005" \
 	TEST_VALKEY_CLUSTER_PASSWORD_URI="redis://localhost:17006" \
+	TEST_VALKEY_CLUSTER_PASSWORD_TLS_URI="redis://localhost:17012" \
+	TEST_VALKEY_CLUSTER_PASSWORD="redis-password" \
 	TEST_TILE38_URI="redis://localhost:19851" \
 	TEST_VALKEY_SENTINEL_URI="redis://localhost:26379" \
 	go test -v -covermode=atomic -cover -race -coverprofile=coverage.txt -p 1 ./...

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ test:
 	TEST_REDIS88_CLUSTER_MASTER_URI="redis://localhost:47000" \
 	TEST_REDIS_CLUSTER_SLAVE_URI="redis://localhost:17005" \
 	TEST_VALKEY_CLUSTER_PASSWORD_URI="redis://localhost:17006" \
-	TEST_VALKEY_CLUSTER_PASSWORD_TLS_URI="redis://localhost:17012" \
+	TEST_VALKEY_CLUSTER_PASSWORD_TLS_URI="rediss://localhost:17012" \
 	TEST_VALKEY_CLUSTER_PASSWORD="redis-password" \
 	TEST_TILE38_URI="redis://localhost:19851" \
 	TEST_VALKEY_SENTINEL_URI="redis://localhost:26379" \

--- a/README.md
+++ b/README.md
@@ -110,6 +110,15 @@ scrape_configs:
         - <<REDIS-EXPORTER-HOSTNAME>>:9121
 ```
 
+The `/scrape` endpoint accepts a few per-target query parameters that override the
+exporter's defaults for that request: `check-keys`, `check-single-keys`,
+`check-streams`, `check-single-streams`, `count-keys`, and `tls-server-name`.
+For TLS targets (`rediss://` / `valkeys://`) the SNI server name defaults to the
+target's own host, so each host is validated against its own certificate. Set
+`tls-server-name` only when the certificate's name differs from the host you
+connect to (for example when scraping through a proxy or by IP address):
+`…/scrape?target=rediss://10.0.0.5:6379&tls-server-name=redis.internal`.
+
 The Redis instances are listed under `targets`, the Redis exporter hostname is configured via the last relabel_config rule.\
 If authentication is needed for the Redis instances then you can set the password via the `--redis.password` command line option of
 the exporter (this means you can currently only use one password across the instances you try to scrape this way. Use several
@@ -156,6 +165,7 @@ Prometheus uses file watches and all changes to the json file are applied immedi
 
 When using a Redis Cluster, the exporter provides a discovery endpoint that can be used to discover all nodes in the cluster.
 To use this feature, pass the cluster configuration endpoint as the target parameter. Nodes discovered will subsequently be scraped for metrics using the same scheme and authentication credentials used for the discovery.
+For a TLS cluster (`rediss://` / `valkeys://`) each discovered node is scraped over TLS and validated against its own certificate (the SNI server name defaults to the node's host), so no extra TLS configuration is needed; use the `tls-server-name` `/scrape` parameter only if a node's certificate name differs from its address.
 The discovery endpoint is available at `/discover-cluster-nodes` and can be used in the Prometheus configuration like this:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -155,14 +155,14 @@ Prometheus uses file watches and all changes to the json file are applied immedi
 ### Prometheus Configuration to Scrape All Nodes in a Redis Cluster
 
 When using a Redis Cluster, the exporter provides a discovery endpoint that can be used to discover all nodes in the cluster.
-To use this feature, the exporter must be started with the `--is-cluster` flag.\
+To use this feature, pass the cluster configuration endpoint as the target parameter. Nodes discovered will subsequently be scraped for metrics using the same scheme and authentication credentials used for the discovery.
 The discovery endpoint is available at `/discover-cluster-nodes` and can be used in the Prometheus configuration like this:
 
 ```yaml
 scrape_configs:
   - job_name: 'redis_exporter_cluster_nodes'
     http_sd_configs:
-      - url: http://<<REDIS-EXPORTER-HOSTNAME>>:9121/discover-cluster-nodes
+      - url: http://<<REDIS-EXPORTER-HOSTNAME>>:9121/discover-cluster-nodes?target=redis://clustercfg:6379
         refresh_interval: 10m
     metrics_path: /scrape
     relabel_configs:

--- a/contrib/tls/gen-test-certs.sh
+++ b/contrib/tls/gen-test-certs.sh
@@ -29,4 +29,5 @@ openssl req \
         -CAserial ${dir}/ca.txt \
         -CAcreateserial \
         -days 3650 \
+        -extfile <(echo "subjectAltName=DNS:localhost") \
         -out ${dir}/redis.crt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,7 +128,25 @@ services:
       - VALKEY_PASSWORD=redis-password
     ports:
       - "17006:7006"
+      - "7006-7011:7006-7011"
 
+  valkey-cluster-password-tls:
+    image: oliver006/valkey-cluster:8.1.3
+    volumes:
+      - ./contrib/tls:/tls
+    command: |
+      valkey-cluster --enable-debug-command yes --protected-mode no
+      --tls-port 6379 --port 0
+      --tls-cert-file     /tls/redis.crt
+      --tls-key-file      /tls/redis.key
+      --tls-ca-cert-file  /tls/ca.crt
+    environment:
+      - IP=0.0.0.0
+      - INITIAL_PORT=7012
+      - VALKEY_PASSWORD=redis-password
+    ports:
+      - "17012:7012"
+      - "7012-7017:7012-7017"
 
   valkey-sentinel:
     image: valkey/valkey:9

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,7 +103,8 @@ services:
       - "16402:6379"
 
   valkey-cluster:
-    image: oliver006/valkey-cluster:8.1.3
+    image: oliver006/valkey-cluster:8.1.4
+    command: valkey-cluster
     environment:
       - IP=0.0.0.0
     ports:
@@ -121,7 +122,9 @@ services:
       - 47000-47005:47000-47005
 
   valkey-cluster-password:
-    image: oliver006/valkey-cluster:8.1.3
+    image: oliver006/valkey-cluster:8.1.4
+    command: |
+      valkey-cluster --port 7006
     environment:
       - IP=0.0.0.0
       - INITIAL_PORT=7006
@@ -131,12 +134,12 @@ services:
       - "7006-7011:7006-7011"
 
   valkey-cluster-password-tls:
-    image: oliver006/valkey-cluster:8.1.3
+    image: oliver006/valkey-cluster:8.1.4
     volumes:
       - ./contrib/tls:/tls
     command: |
-      valkey-cluster --enable-debug-command yes --protected-mode no
-      --tls-port 6379 --port 0
+      valkey-cluster
+      --tls-port 7012 --port 0
       --tls-cert-file     /tls/redis.crt
       --tls-key-file      /tls/redis.key
       --tls-ca-cert-file  /tls/ca.crt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,7 +103,7 @@ services:
       - "16402:6379"
 
   valkey-cluster:
-    image: oliver006/valkey-cluster:8.1.4
+    image: oliver006/valkey-cluster:8.1.5
     command: valkey-cluster
     environment:
       - IP=0.0.0.0
@@ -122,7 +122,7 @@ services:
       - 47000-47005:47000-47005
 
   valkey-cluster-password:
-    image: oliver006/valkey-cluster:8.1.4
+    image: oliver006/valkey-cluster:8.1.5
     command: |
       valkey-cluster --port 7006
     environment:
@@ -134,7 +134,7 @@ services:
       - "7006-7011:7006-7011"
 
   valkey-cluster-password-tls:
-    image: oliver006/valkey-cluster:8.1.4
+    image: oliver006/valkey-cluster:8.1.5
     volumes:
       - ./contrib/tls:/tls
     command: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,7 @@ services:
       - 47000-47005:47000-47005
 
   valkey-cluster-password:
-    image: oliver006/valkey-cluster:8.1.5
+    image: oliver006/valkey-cluster:9.0.1
     command: |
       valkey-cluster --port 7006
     environment:
@@ -134,7 +134,7 @@ services:
       - "7006-7011:7006-7011"
 
   valkey-cluster-password-tls:
-    image: oliver006/valkey-cluster:8.1.5
+    image: oliver006/valkey-cluster:9.0.1
     volumes:
       - ./contrib/tls:/tls
     command: |

--- a/exporter/clients_test.go
+++ b/exporter/clients_test.go
@@ -144,7 +144,7 @@ func TestParseClientListString(t *testing.T) {
 
 func TestExportClientList(t *testing.T) {
 	for _, isExportClientList := range []bool{true, false} {
-		e := getTestExporterWithOptions(Options{
+		e := getTestExporterWithOptions(t, Options{
 			Namespace:        "test",
 			ExportClientList: isExportClientList,
 		})
@@ -241,7 +241,7 @@ func TestExportClientListRedis7(t *testing.T) {
 
 func TestExportClientListInclPort(t *testing.T) {
 	for _, inclPort := range []bool{true, false} {
-		e := getTestExporterWithOptions(Options{
+		e := getTestExporterWithOptions(t, Options{
 			Namespace:             "test",
 			ExportClientList:      true,
 			ExportClientsInclPort: inclPort,

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -46,6 +46,9 @@ type Exporter struct {
 	mux *http.ServeMux
 
 	buildInfo BuildInfo
+
+	DiscoveredNodesPasswords      map[string]string
+	DiscoveredNodesPasswordsMutex sync.Mutex
 }
 
 type Options struct {
@@ -152,6 +155,8 @@ func NewRedisExporter(uri string, opts Options) (*Exporter, error) {
 			Name:      "target_scrape_request_errors_total",
 			Help:      "Errors in requests to the exporter",
 		}),
+
+		DiscoveredNodesPasswords: make(map[string]string),
 
 		metricMapGauges: map[string]string{
 			// # Server
@@ -752,7 +757,7 @@ func (e *Exporter) extractConfigMetrics(ch chan<- prometheus.Metric, config map[
 			}
 		}
 	}
-	return
+	return dbCount, err
 }
 
 func (e *Exporter) scrapeRedisHost(ch chan<- prometheus.Metric) error {

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -71,6 +71,7 @@ type Options struct {
 	ClientCertFile                 string
 	ClientKeyFile                  string
 	CaCertFile                     string
+	TlsServerName                  string
 	InclConfigMetrics              bool
 	InclModulesMetrics             bool
 	InclSearchIndexesMetrics       bool

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -66,14 +66,14 @@ var (
 	TestKeyNameHll          = "test-hll"
 )
 
-func getTestExporter() *Exporter {
-	return getTestExporterWithOptions(Options{Namespace: "test"})
+func getTestExporter(t *testing.T) *Exporter {
+	return getTestExporterWithOptions(t, Options{Namespace: "test"})
 }
 
-func getTestExporterWithOptions(opt Options) *Exporter {
+func getTestExporterWithOptions(t *testing.T, opt Options) *Exporter {
 	addr := os.Getenv("TEST_REDIS_URI")
 	if addr == "" {
-		panic("missing env var TEST_REDIS_URI")
+		t.Skip("missing env var TEST_REDIS_URI")
 	}
 	e, _ := NewRedisExporter(addr, opt)
 	return e
@@ -383,7 +383,7 @@ func TestClientOutputBufferLimitMetrics(t *testing.T) {
 }
 
 func TestConfigReplBacklogSizeMetric(t *testing.T) {
-	e := getTestExporter()
+	e := getTestExporter(t)
 	ts := httptest.NewServer(e)
 	defer ts.Close()
 

--- a/exporter/http.go
+++ b/exporter/http.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/gomodule/redigo/redis"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
@@ -65,6 +66,10 @@ func (e *Exporter) scrapeHandler(w http.ResponseWriter, r *http.Request) {
 
 	opts := e.options
 
+	if pwd, ok := e.lookupPasswordInPasswordMap(target); ok {
+		opts.Password = pwd
+	}
+
 	// get rid of username/password info in "target" so users don't send them in plain text via http
 	// and save "user" in options so we can use it later when connecting to the redis instance
 	// the password will be looked up from the password file
@@ -109,12 +114,30 @@ func (e *Exporter) scrapeHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (e *Exporter) discoverClusterNodesHandler(w http.ResponseWriter, r *http.Request) {
-	if !e.options.IsCluster {
-		http.Error(w, "The discovery endpoint is only available on a redis cluster", http.StatusBadRequest)
-		return
+	target := r.URL.Query().Get("target")
+	var c redis.Conn
+	var err error
+
+	// Store the original scheme for output
+	originalScheme := "redis" // Default to redis
+	if strings.HasPrefix(target, "rediss://") {
+		originalScheme = "rediss"
+	} else if strings.HasPrefix(target, "valkey://") {
+		originalScheme = "valkey"
+	} else if strings.HasPrefix(target, "valkeys://") {
+		originalScheme = "valkeys"
 	}
 
-	c, err := e.connectToRedisCluster()
+	if target == "" {
+		if !e.options.IsCluster {
+			http.Error(w, "The discovery endpoint is only available on a redis cluster", http.StatusBadRequest)
+			return
+		}
+		c, err = e.connectToRedisCluster()
+	} else {
+		c, err = e.connectToRedisClusterWithURI(target)
+	}
+
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Couldn't connect to redis cluster: %s", err), http.StatusInternalServerError)
 		return
@@ -127,6 +150,18 @@ func (e *Exporter) discoverClusterNodesHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	if target != "" {
+		if password, ok := e.lookupPasswordInPasswordMap(target); ok {
+			e.DiscoveredNodesPasswordsMutex.Lock()
+			for _, node := range nodes {
+				nodeAddr := fmt.Sprintf("%s://%s", originalScheme, node)
+				e.DiscoveredNodesPasswords[nodeAddr] = password
+				log.Debugf("Cached password for discovered node: %s", nodeAddr)
+			}
+			e.DiscoveredNodesPasswordsMutex.Unlock()
+		}
+	}
+
 	discovery := []struct {
 		Targets []string          `json:"targets"`
 		Labels  map[string]string `json:"labels"`
@@ -137,13 +172,8 @@ func (e *Exporter) discoverClusterNodesHandler(w http.ResponseWriter, r *http.Re
 		},
 	}
 
-	isTls := strings.HasPrefix(e.redisAddr, "rediss://")
 	for i, node := range nodes {
-		if isTls {
-			discovery[0].Targets[i] = "rediss://" + node
-		} else {
-			discovery[0].Targets[i] = "redis://" + node
-		}
+		discovery[0].Targets[i] = fmt.Sprintf("%s://%s", originalScheme, node)
 	}
 
 	data, err := json.MarshalIndent(discovery, "", "  ")

--- a/exporter/http.go
+++ b/exporter/http.go
@@ -99,6 +99,11 @@ func (e *Exporter) scrapeHandler(w http.ResponseWriter, r *http.Request) {
 		opts.CountKeys = cntk
 	}
 
+	// SNI is per-target: default to per-host (empty => redigo uses the dial
+	// host) so discovered cluster nodes each validate against their own cert,
+	// with an explicit override for proxy/cert mismatch cases.
+	opts.TlsServerName = r.URL.Query().Get("tls-server-name")
+
 	opts.Registry = prometheus.NewRegistry()
 
 	_, err = NewRedisExporter(target, opts)
@@ -118,15 +123,14 @@ func (e *Exporter) discoverClusterNodesHandler(w http.ResponseWriter, r *http.Re
 	var c redis.Conn
 	var err error
 
-	// Store the original scheme for output
-	originalScheme := "redis" // Default to redis
-	if strings.HasPrefix(target, "rediss://") {
-		originalScheme = "rediss"
-	} else if strings.HasPrefix(target, "valkey://") {
-		originalScheme = "valkey"
-	} else if strings.HasPrefix(target, "valkeys://") {
-		originalScheme = "valkeys"
+	// Preserve the original scheme for the discovery output. For the no-target
+	// path fall back to the exporter's own address so a rediss:// cluster keeps
+	// emitting rediss:// nodes.
+	schemeSource := target
+	if schemeSource == "" {
+		schemeSource = e.redisAddr
 	}
+	originalScheme := schemeFromURI(schemeSource)
 
 	if target == "" {
 		if !e.options.IsCluster {
@@ -155,8 +159,15 @@ func (e *Exporter) discoverClusterNodesHandler(w http.ResponseWriter, r *http.Re
 			e.DiscoveredNodesPasswordsMutex.Lock()
 			for _, node := range nodes {
 				nodeAddr := fmt.Sprintf("%s://%s", originalScheme, node)
-				e.DiscoveredNodesPasswords[nodeAddr] = password
-				log.Debugf("Cached password for discovered node: %s", nodeAddr)
+				// Use the same key normalisation as the lookup so a scrape of
+				// the discovered node finds this entry (e.g. when --redis-user
+				// injects a username into the lookup URI).
+				key, err := e.canonicalPasswordKey(nodeAddr)
+				if err != nil {
+					continue
+				}
+				e.DiscoveredNodesPasswords[key] = password
+				log.Debugf("Cached password for discovered node: %s", key)
 			}
 			e.DiscoveredNodesPasswordsMutex.Unlock()
 		}
@@ -201,6 +212,13 @@ func (e *Exporter) reloadPwdFile(w http.ResponseWriter, r *http.Request) {
 	e.Lock()
 	e.options.PasswordMap = passwordMap
 	e.Unlock()
+
+	// Invalidate cached discovered-node passwords so rotated credentials are
+	// not served from stale entries after a reload.
+	e.DiscoveredNodesPasswordsMutex.Lock()
+	e.DiscoveredNodesPasswords = make(map[string]string)
+	e.DiscoveredNodesPasswordsMutex.Unlock()
+
 	_, _ = w.Write([]byte(`ok`))
 }
 

--- a/exporter/http_test.go
+++ b/exporter/http_test.go
@@ -1,6 +1,7 @@
 package exporter
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"math/rand"
@@ -871,6 +872,401 @@ func TestValidateBasicAuthPassword(t *testing.T) {
 			st := e.validateBasicAuthPassword(tt.inputPassword)
 			if st != tt.expectStatus {
 				t.Errorf("Expected error: %v, got: %v", tt.expectStatus, st)
+			}
+		})
+	}
+}
+
+func TestDiscoverClusterNodesHandlerWithTarget(t *testing.T) {
+	clusterAddr := os.Getenv("TEST_REDIS_CLUSTER_MASTER_URI")
+	valkeyClusterAddr := os.Getenv("TEST_VALKEY_CLUSTER_PASSWORD_URI")
+	valkeyClusterPassword := os.Getenv("TEST_VALKEY_CLUSTER_PASSWORD")
+	if clusterAddr == "" || valkeyClusterAddr == "" || valkeyClusterPassword == "" {
+		t.Skipf("TEST_REDIS_CLUSTER_MASTER_URI or TEST_VALKEY_CLUSTER_PASSWORD_URI or TEST_VALKEY_CLUSTER_PASSWORD not set - skipping")
+	}
+
+	testCases := []struct {
+		name       string
+		addr       string
+		wantScheme string
+		auth       string
+		wants      []string
+	}{
+		{
+			name:       "redis_cluster",
+			addr:       clusterAddr,
+			auth:       "",
+			wantScheme: "redis",
+			wants: []string{
+				"127.0.0.1:7000",
+				"127.0.0.1:7001",
+				"127.0.0.1:7002",
+			},
+		},
+		{
+			name:       "valkey_cluster",
+			addr:       valkeyClusterAddr,
+			auth:       valkeyClusterPassword,
+			wantScheme: "redis", // TODO: change to "valkey" when valkey starts using valkey:// scheme internally
+			wants: []string{
+				"127.0.0.1:7006",
+				"127.0.0.1:7007",
+				"127.0.0.1:7008",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			passwordMap := map[string]string{
+				tc.addr: tc.auth,
+			}
+
+			e, _ := NewRedisExporter("", Options{
+				Namespace:   "test",
+				PasswordMap: passwordMap,
+			})
+			ts := httptest.NewServer(e)
+			defer ts.Close()
+
+			u, _ := url.Parse(ts.URL + "/discover-cluster-nodes")
+			q := u.Query()
+			q.Set("target", tc.addr)
+			u.RawQuery = q.Encode()
+
+			statusCode, body := downloadURLWithStatusCode(t, u.String())
+			if statusCode != http.StatusOK {
+				t.Fatalf("expected status code 200, got %d, body:\n\n%s", statusCode, body)
+			}
+
+			var discovery []struct {
+				Targets []string          `json:"targets"`
+				Labels  map[string]string `json:"labels"`
+			}
+
+			err := json.Unmarshal([]byte(body), &discovery)
+			if err != nil {
+				t.Fatalf("failed to unmarshal json: %s, body:\n\n%s", err, body)
+			}
+			t.Logf("Discovered nodes: %v", discovery[0].Targets)
+
+			if len(discovery) != 1 {
+				t.Fatalf("expected 1 discovery target, got %d", len(discovery))
+			}
+
+			// The cluster has 3 masters and 3 slaves, so 6 nodes in total.
+			if len(discovery[0].Targets) < 3 {
+				t.Fatalf("expected at least 3 targets, got %d", len(discovery[0].Targets))
+			}
+
+			// check if we have the masters
+			for _, want := range tc.wants {
+				found := false
+				for _, target := range discovery[0].Targets {
+					if !strings.HasPrefix(target, tc.wantScheme+"://") {
+						t.Errorf("expected scheme %s, got %s", tc.wantScheme, target)
+					}
+					if strings.Contains(target, want) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("want target %q, but not found in %v", want, discovery[0].Targets)
+				}
+			}
+		})
+	}
+}
+
+func TestDiscoverClusterNodesHandlerTLS(t *testing.T) {
+	clusterAddr := os.Getenv("TEST_VALKEY_CLUSTER_PASSWORD_TLS_URI")
+	clusterPassword := os.Getenv("TEST_VALKEY_CLUSTER_PASSWORD")
+	if clusterAddr == "" || clusterPassword == "" {
+		t.Skipf("TEST_VALKEY_CLUSTER_PASSWORD or TEST_VALKEY_CLUSTER_PASSWORD_TLS_URI not set - skipping")
+	}
+
+	testCases := []struct {
+		name           string
+		addr           string
+		auth           string
+		wantScheme     string
+		wantStatusCode int
+		wants          []string
+	}{
+		{
+			name:           "rediss",
+			addr:           clusterAddr,
+			auth:           clusterPassword,
+			wantScheme:     "rediss",
+			wantStatusCode: http.StatusOK,
+			wants: []string{
+				"127.0.0.1:7012",
+				"127.0.0.1:7013",
+				"127.0.0.1:7014",
+			},
+		},
+		{
+			name:           "valkeys",
+			addr:           strings.Replace(clusterAddr, "rediss://", "valkeys://", 1),
+			auth:           clusterPassword,
+			wantScheme:     "valkeys",
+			wantStatusCode: http.StatusOK,
+			wants: []string{
+				"127.0.0.1:7012",
+				"127.0.0.1:7013",
+				"127.0.0.1:7014",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			targetURI := tc.addr
+
+			passwordMap := map[string]string{
+				tc.addr: tc.auth,
+			}
+
+			e, _ := NewRedisExporter("", Options{
+				Namespace:           "test",
+				PasswordMap:         passwordMap,
+				SkipTLSVerification: true,
+				ClientCertFile:      "../contrib/tls/redis.crt",
+				ClientKeyFile:       "../contrib/tls/redis.key",
+				CaCertFile:          "../contrib/tls/ca.crt",
+			})
+			ts := httptest.NewServer(e)
+			defer ts.Close()
+
+			u, _ := url.Parse(ts.URL + "/discover-cluster-nodes")
+			q := u.Query()
+			q.Set("target", targetURI)
+			u.RawQuery = q.Encode()
+
+			statusCode, body := downloadURLWithStatusCode(t, u.String())
+			if statusCode != tc.wantStatusCode {
+				t.Fatalf("expected status code %d, got %d, body:\n\n%s", tc.wantStatusCode, statusCode, body)
+			}
+
+			if tc.wantStatusCode == http.StatusOK {
+				var discovery []struct {
+					Targets []string          `json:"targets"`
+					Labels  map[string]string `json:"labels"`
+				}
+
+				err := json.Unmarshal([]byte(body), &discovery)
+				if err != nil {
+					t.Fatalf("failed to unmarshal json: %s, body:\n\n%s", err, body)
+				}
+				t.Logf("Discovered nodes: %v", discovery[0].Targets)
+
+				if len(discovery) != 1 {
+					t.Fatalf("expected 1 discovery target, got %d", len(discovery))
+				}
+
+				// The cluster has 3 masters and 3 slaves, so 6 nodes in total.
+				if len(discovery[0].Targets) < 3 {
+					t.Fatalf("expected at least 3 targets, got %d", len(discovery[0].Targets))
+				}
+
+				// check if we have the masters
+				for _, want := range tc.wants {
+					found := false
+					for _, target := range discovery[0].Targets {
+						if !strings.HasPrefix(target, tc.wantScheme+"://") {
+							t.Errorf("expected scheme %s, got %s", tc.wantScheme, target)
+						}
+						if strings.Contains(target, want) {
+							found = true
+							break
+						}
+					}
+					if !found {
+						t.Errorf("want target %q, but not found in %v", want, discovery[0].Targets)
+					}
+				}
+			} else {
+				if !strings.Contains(body, "This instance has cluster support disabled") && !strings.Contains(body, "EOF") {
+					t.Errorf("expected error message, got: %s", body)
+				}
+			}
+		})
+	}
+}
+
+func TestDiscoverClusterNodesHandlerAuthFail(t *testing.T) {
+	clusterAddr := os.Getenv("TEST_VALKEY_CLUSTER_PASSWORD_URI")
+	if clusterAddr == "" {
+		t.Skipf("TEST_VALKEY_CLUSTER_PASSWORD_URI not set - skipping")
+	}
+
+	e, _ := NewRedisExporter("", Options{Namespace: "test"})
+	ts := httptest.NewServer(e)
+	defer ts.Close()
+
+	u, _ := url.Parse(ts.URL + "/discover-cluster-nodes")
+	q := u.Query()
+	q.Set("target", clusterAddr)
+	u.RawQuery = q.Encode()
+
+	statusCode, body := downloadURLWithStatusCode(t, u.String())
+	if statusCode != http.StatusInternalServerError {
+		t.Fatalf("expected status code 500, got %d", statusCode)
+	}
+
+	if !strings.Contains(body, "NOAUTH Authentication required") {
+		t.Errorf("expected error message, got: %s", body)
+	}
+}
+
+func TestScrapeDiscoveredNodeWithCachedPassword(t *testing.T) {
+	clusterAddr := os.Getenv("TEST_VALKEY_CLUSTER_PASSWORD_URI")
+	clusterPass := os.Getenv("TEST_VALKEY_CLUSTER_PASSWORD")
+	if clusterAddr == "" || clusterPass == "" {
+		t.Skipf("TEST_VALKEY_CLUSTER_PASSWORD_URI or TEST_VALKEY_CLUSTER_PASSWORD not set - skipping")
+	}
+
+	passwordMap := map[string]string{
+		clusterAddr: clusterPass,
+	}
+
+	e, _ := NewRedisExporter("", Options{
+		Namespace:   "test",
+		PasswordMap: passwordMap,
+	})
+	ts := httptest.NewServer(e)
+	defer ts.Close()
+
+	// 1. Discover cluster nodes
+	discoverURL, _ := url.Parse(ts.URL + "/discover-cluster-nodes")
+	q := discoverURL.Query()
+	q.Set("target", clusterAddr)
+	discoverURL.RawQuery = q.Encode()
+
+	discoverStatusCode, discoverBody := downloadURLWithStatusCode(t, discoverURL.String())
+	if discoverStatusCode != http.StatusOK {
+		t.Fatalf("discover endpoint expected status code 200, got %d, body:\n\n%s", discoverStatusCode, discoverBody)
+	}
+
+	var discovery []struct {
+		Targets []string          `json:"targets"`
+		Labels  map[string]string `json:"labels"`
+	}
+
+	err := json.Unmarshal([]byte(discoverBody), &discovery)
+	if err != nil {
+		t.Fatalf("failed to unmarshal discovery json: %s, body:\n\n%s", err, discoverBody)
+	}
+
+	if len(discovery) == 0 || len(discovery[0].Targets) == 0 {
+		t.Fatalf("no targets discovered")
+	}
+
+	// 2. Scrape a discovered node
+	discoveredNodeURI := discovery[0].Targets[0]
+	scrapeURL, _ := url.Parse(ts.URL + "/scrape")
+	q = scrapeURL.Query()
+	q.Set("target", discoveredNodeURI)
+	scrapeURL.RawQuery = q.Encode()
+
+	scrapeStatusCode, scrapeBody := downloadURLWithStatusCode(t, scrapeURL.String())
+	if scrapeStatusCode != http.StatusOK {
+		t.Fatalf("scrape endpoint expected status code 200, got %d, body:\n\n%s", scrapeStatusCode, scrapeBody)
+	}
+
+	// Assert some metric is present to confirm successful scrape
+	if !strings.Contains(scrapeBody, "test_up 1") {
+		t.Errorf("expected 'test_up 1' in scrape body, got: %s", scrapeBody)
+	}
+}
+
+func TestScrapeDiscoveredClusterNodesTLS(t *testing.T) {
+	clusterAddr := os.Getenv("TEST_VALKEY_CLUSTER_PASSWORD_TLS_URI")
+	clusterPassword := os.Getenv("TEST_VALKEY_CLUSTER_PASSWORD")
+	if clusterAddr == "" || clusterPassword == "" {
+		t.Skipf("TEST_VALKEY_CLUSTER_PASSWORD or TEST_VALKEY_CLUSTER_PASSWORD_TLS_URI not set - skipping")
+	}
+
+	testCases := []struct {
+		name       string
+		addr       string
+		auth       string
+		wantScheme string
+	}{
+		{
+			name:       "rediss",
+			addr:       clusterAddr,
+			auth:       clusterPassword,
+			wantScheme: "rediss",
+		},
+		{
+			name:       "valkeys",
+			addr:       strings.Replace(clusterAddr, "rediss://", "valkeys://", 1),
+			auth:       clusterPassword,
+			wantScheme: "valkeys",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			passwordMap := map[string]string{
+				tc.addr: tc.auth,
+			}
+
+			e, _ := NewRedisExporter("", Options{
+				Namespace:           "test",
+				PasswordMap:         passwordMap,
+				SkipTLSVerification: true,
+				ClientCertFile:      "../contrib/tls/redis.crt",
+				ClientKeyFile:       "../contrib/tls/redis.key",
+				CaCertFile:          "../contrib/tls/ca.crt",
+			})
+			ts := httptest.NewServer(e)
+			defer ts.Close()
+
+			discoverURL, _ := url.Parse(ts.URL + "/discover-cluster-nodes")
+			q := discoverURL.Query()
+			q.Set("target", tc.addr)
+			discoverURL.RawQuery = q.Encode()
+
+			discoverStatusCode, discoverBody := downloadURLWithStatusCode(t, discoverURL.String())
+			if discoverStatusCode != http.StatusOK {
+				t.Fatalf("discover endpoint expected status code 200, got %d, body:\n\n%s", discoverStatusCode, discoverBody)
+			}
+
+			var discovery []struct {
+				Targets []string          `json:"targets"`
+				Labels  map[string]string `json:"labels"`
+			}
+
+			err := json.Unmarshal([]byte(discoverBody), &discovery)
+			if err != nil {
+				t.Fatalf("failed to unmarshal discovery json: %s, body:\n\n%s", err, discoverBody)
+			}
+
+			if len(discovery) == 0 || len(discovery[0].Targets) == 0 {
+				t.Fatalf("no targets discovered")
+			}
+			t.Logf("Discovered nodes: %v", discovery[0].Targets)
+
+			for _, discoveredNodeURI := range discovery[0].Targets {
+				t.Run(fmt.Sprintf("scraping node %s", discoveredNodeURI), func(t *testing.T) {
+					scrapeURL, _ := url.Parse(ts.URL + "/scrape")
+					q = scrapeURL.Query()
+					q.Set("target", discoveredNodeURI)
+					scrapeURL.RawQuery = q.Encode()
+
+					scrapeStatusCode, scrapeBody := downloadURLWithStatusCode(t, scrapeURL.String())
+					if scrapeStatusCode != http.StatusOK {
+						t.Fatalf("scrape endpoint expected status code 200, got %d, body:\n\n%s", scrapeStatusCode, scrapeBody)
+					}
+
+					// Assert some metric is present to confirm successful scrape
+					if !strings.Contains(scrapeBody, "test_up 1") {
+						t.Errorf("expected 'test_up 1' in scrape body, got: %s", scrapeBody)
+					}
+				})
 			}
 		})
 	}

--- a/exporter/latency_test.go
+++ b/exporter/latency_test.go
@@ -18,7 +18,7 @@ const (
 )
 
 func TestLatencySpike(t *testing.T) {
-	e := getTestExporter()
+	e := getTestExporter(t)
 
 	setupLatency(t, os.Getenv("TEST_REDIS_URI"))
 	defer resetLatency(t, os.Getenv("TEST_REDIS_URI"))

--- a/exporter/metrics_test.go
+++ b/exporter/metrics_test.go
@@ -23,7 +23,7 @@ func TestSanitizeMetricName(t *testing.T) {
 func TestRegisterConstHistogram(t *testing.T) {
 	metricName := "foo"
 	for _, inc := range []bool{false, true} {
-		exp := getTestExporterWithOptions(Options{Namespace: "test", AppendInstanceRoleLabel: inc})
+		exp := getTestExporterWithOptions(t, Options{Namespace: "test", AppendInstanceRoleLabel: inc})
 		ch := make(chan prometheus.Metric)
 		go func() {
 			exp.createMetricDescription(metricName, []string{"test"})
@@ -49,7 +49,7 @@ func TestRegisterConstHistogram(t *testing.T) {
 func TestRegisterConstMetric(t *testing.T) {
 	metricName := "bar"
 	for _, inc := range []bool{false, true} {
-		exp := getTestExporterWithOptions(Options{Namespace: "test", AppendInstanceRoleLabel: inc})
+		exp := getTestExporterWithOptions(t, Options{Namespace: "test", AppendInstanceRoleLabel: inc})
 		ch := make(chan prometheus.Metric)
 		go func() {
 			exp.createMetricDescription(metricName, []string{"test"})
@@ -73,7 +73,7 @@ func TestRegisterConstMetric(t *testing.T) {
 }
 
 func TestFindOrCreateMetricsDescriptionFindExisting(t *testing.T) {
-	exp := getTestExporter()
+	exp := getTestExporter(t)
 	exp.metricDescriptions = map[string]*prometheus.Desc{}
 
 	metricName := "foo"
@@ -92,7 +92,7 @@ func TestFindOrCreateMetricsDescriptionFindExisting(t *testing.T) {
 }
 
 func TestFindOrCreateMetricsDescriptionCreateNew(t *testing.T) {
-	exp := getTestExporter()
+	exp := getTestExporter(t)
 	exp.metricDescriptions = map[string]*prometheus.Desc{}
 
 	metricName := "foo"

--- a/exporter/redis.go
+++ b/exporter/redis.go
@@ -11,12 +11,60 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (e *Exporter) configureOptions(uri string, useTLS bool) ([]redis.DialOption, error) {
+// schemeIsTLS reports whether a redis URI uses a TLS scheme.
+func schemeIsTLS(uri string) bool {
+	return strings.HasPrefix(uri, "rediss://") || strings.HasPrefix(uri, "valkeys://")
+}
+
+// schemeFromURI returns the URI scheme (redis, rediss, valkey, valkeys),
+// defaulting to "redis" when no recognised scheme prefix is present.
+func schemeFromURI(uri string) string {
+	// "valkeys" before "valkey" and "rediss" before "redis" so the longer
+	// (TLS) prefixes win.
+	for _, s := range []string{"rediss", "valkeys", "valkey", "redis"} {
+		if strings.HasPrefix(uri, s+"://") {
+			return s
+		}
+	}
+	return "redis"
+}
+
+// startupNodeFromURI strips the scheme from a redis URI and returns a
+// host:port string suitable for redisc.Cluster.StartupNodes, defaulting the
+// port to 6379 when absent. Callers must pass a URI that includes a scheme.
+func startupNodeFromURI(uri string) (string, error) {
 	u, err := url.Parse(uri)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse redis uri: %w", err)
+		return "", fmt.Errorf("failed to parse cluster URI: %w", err)
 	}
-	tlsConfig, err := e.CreateClientTLSConfig(u.Hostname())
+	if u.Port() == "" {
+		return u.Host + ":6379", nil
+	}
+	return u.Host, nil
+}
+
+// canonicalPasswordKey normalises a redis URI to the form used as a key in the
+// password maps: the user from options is applied and a bare ":" left by a
+// username-without-password is stripped. The same normalisation must be used
+// when caching and looking up passwords so the keys match.
+func (e *Exporter) canonicalPasswordKey(uri string) (string, error) {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return "", err
+	}
+
+	if e.options.User != "" {
+		u.User = url.User(e.options.User)
+	}
+	key := u.String()
+
+	// strip solo ":" if present in uri that has a username (and no pwd)
+	key = strings.Replace(key, fmt.Sprintf(":@%s", u.Host), fmt.Sprintf("@%s", u.Host), 1)
+	return key, nil
+}
+
+func (e *Exporter) configureOptions(uri string, useTLS bool) ([]redis.DialOption, error) {
+	tlsConfig, err := e.CreateClientTLSConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -45,28 +93,20 @@ func (e *Exporter) configureOptions(uri string, useTLS bool) ([]redis.DialOption
 }
 
 func (e *Exporter) lookupPasswordInPasswordMap(uri string) (string, bool) {
-	u, err := url.Parse(uri)
+	key, err := e.canonicalPasswordKey(uri)
 	if err != nil {
 		return "", false
 	}
 
-	if e.options.User != "" {
-		u.User = url.User(e.options.User)
-	}
-	uri = u.String()
-
-	// strip solo ":" if present in uri that has a username (and no pwd)
-	uri = strings.Replace(uri, fmt.Sprintf(":@%s", u.Host), fmt.Sprintf("@%s", u.Host), 1)
-
-	log.Debugf("looking up in pwd map, uri: %s", uri)
-	if pwd, ok := e.options.PasswordMap[uri]; ok && pwd != "" {
+	log.Debugf("looking up in pwd map, uri: %s", key)
+	if pwd, ok := e.options.PasswordMap[key]; ok && pwd != "" {
 		return pwd, true
 	}
 
 	e.DiscoveredNodesPasswordsMutex.Lock()
 	defer e.DiscoveredNodesPasswordsMutex.Unlock()
-	if pwd, ok := e.DiscoveredNodesPasswords[uri]; ok && pwd != "" {
-		log.Debugf("found password for discovered node %s", uri)
+	if pwd, ok := e.DiscoveredNodesPasswords[key]; ok && pwd != "" {
+		log.Debugf("found password for discovered node %s", key)
 		return pwd, true
 	}
 
@@ -79,7 +119,7 @@ func (e *Exporter) connectToRedis() (redis.Conn, error) {
 		uri = "redis://" + uri
 	}
 
-	options, err := e.configureOptions(uri, strings.HasPrefix(uri, "rediss://") || strings.HasPrefix(uri, "valkeys://"))
+	options, err := e.configureOptions(uri, schemeIsTLS(uri))
 	if err != nil {
 		return nil, err
 	}
@@ -100,55 +140,7 @@ func (e *Exporter) connectToRedis() (redis.Conn, error) {
 }
 
 func (e *Exporter) connectToRedisCluster() (redis.Conn, error) {
-	uri := e.redisAddr
-	if !strings.Contains(uri, "://") {
-		uri = "redis://" + uri
-	}
-
-	options, err := e.configureOptions(uri, strings.HasPrefix(uri, "rediss://") || strings.HasPrefix(uri, "valkeys://"))
-	if err != nil {
-		return nil, err
-	}
-
-	// remove url scheme for redis.Cluster.StartupNodes
-	if strings.Contains(uri, "://") {
-		u, _ := url.Parse(uri)
-		if u.Port() == "" {
-			uri = u.Host + ":6379"
-		} else {
-			uri = u.Host
-		}
-	} else {
-		if frags := strings.Split(uri, ":"); len(frags) != 2 {
-			uri = uri + ":6379"
-		}
-	}
-
-	log.Debugf("Creating cluster object")
-	cluster := redisc.Cluster{
-		StartupNodes: []string{uri},
-		DialOptions:  options,
-	}
-	log.Debugf("Running refresh on cluster object")
-	if err := cluster.Refresh(); err != nil {
-		log.Errorf("Cluster refresh failed: %v", err)
-		return nil, fmt.Errorf("cluster refresh failed: %w", err)
-	}
-
-	log.Debugf("Creating redis connection object")
-	conn, err := cluster.Dial()
-	if err != nil {
-		log.Errorf("Dial failed: %v", err)
-		return nil, fmt.Errorf("dial failed: %w", err)
-	}
-
-	c, err := redisc.RetryConn(conn, 10, 100*time.Millisecond)
-	if err != nil {
-		log.Errorf("RetryConn failed: %v", err)
-		return nil, fmt.Errorf("retryConn failed: %w", err)
-	}
-
-	return c, err
+	return e.connectToRedisClusterWithURI(e.redisAddr)
 }
 
 func (e *Exporter) connectToRedisClusterWithURI(uri string) (redis.Conn, error) {
@@ -156,24 +148,15 @@ func (e *Exporter) connectToRedisClusterWithURI(uri string) (redis.Conn, error) 
 		uri = "redis://" + uri
 	}
 
-	options, err := e.configureOptions(uri, strings.HasPrefix(uri, "rediss://") || strings.HasPrefix(uri, "valkeys://"))
+	options, err := e.configureOptions(uri, schemeIsTLS(uri))
 	if err != nil {
 		return nil, err
 	}
 
 	// remove url scheme for redis.Cluster.StartupNodes
-	startupNode := uri
-	if strings.Contains(startupNode, "://") {
-		u, _ := url.Parse(startupNode)
-		if u.Port() == "" {
-			startupNode = u.Host + ":6379"
-		} else {
-			startupNode = u.Host
-		}
-	} else {
-		if frags := strings.Split(startupNode, ":"); len(frags) != 2 {
-			startupNode = startupNode + ":6379"
-		}
+	startupNode, err := startupNodeFromURI(uri)
+	if err != nil {
+		return nil, err
 	}
 
 	log.Debugf("Creating cluster object")

--- a/exporter/slowlog_test.go
+++ b/exporter/slowlog_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestSlowLog(t *testing.T) {
-	e := getTestExporter()
+	e := getTestExporter(t)
 
 	chM := make(chan prometheus.Metric)
 	go func() {

--- a/exporter/tls.go
+++ b/exporter/tls.go
@@ -10,9 +10,10 @@ import (
 )
 
 // CreateClientTLSConfig verifies configured files and return a prepared tls.Config
-func (e *Exporter) CreateClientTLSConfig() (*tls.Config, error) {
+func (e *Exporter) CreateClientTLSConfig(serverName string) (*tls.Config, error) {
 	tlsConfig := tls.Config{
 		InsecureSkipVerify: e.options.SkipTLSVerification,
+		ServerName:         serverName,
 	}
 
 	if e.options.ClientCertFile != "" && e.options.ClientKeyFile != "" {

--- a/exporter/tls.go
+++ b/exporter/tls.go
@@ -10,10 +10,10 @@ import (
 )
 
 // CreateClientTLSConfig verifies configured files and return a prepared tls.Config
-func (e *Exporter) CreateClientTLSConfig(serverName string) (*tls.Config, error) {
+func (e *Exporter) CreateClientTLSConfig() (*tls.Config, error) {
 	tlsConfig := tls.Config{
 		InsecureSkipVerify: e.options.SkipTLSVerification,
-		ServerName:         serverName,
+		ServerName:         e.options.TlsServerName,
 	}
 
 	if e.options.ClientCertFile != "" && e.options.ClientKeyFile != "" {

--- a/exporter/tls_test.go
+++ b/exporter/tls_test.go
@@ -35,7 +35,7 @@ func TestCreateClientTLSConfig(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			e := getTestExporterWithOptions(test.options)
 
-			_, err := e.CreateClientTLSConfig()
+			_, err := e.CreateClientTLSConfig("")
 			if test.expectSuccess && err != nil {
 				t.Errorf("Expected success for test: %s, got err: %s", test.name, err)
 				return

--- a/exporter/tls_test.go
+++ b/exporter/tls_test.go
@@ -1,6 +1,8 @@
 package exporter
 
 import (
+	"crypto/tls"
+	"net"
 	"os"
 	"strings"
 	"testing"
@@ -17,25 +19,30 @@ func TestCreateClientTLSConfig(t *testing.T) {
 		// positive tests
 		{"no_options", Options{}, true},
 		{"skip_verificaton", Options{
-			SkipTLSVerification: true}, true},
+			SkipTLSVerification: true,
+		}, true},
 		{"load_client_keypair", Options{
 			ClientCertFile: "../contrib/tls/redis.crt",
-			ClientKeyFile:  "../contrib/tls/redis.key"}, true},
+			ClientKeyFile:  "../contrib/tls/redis.key",
+		}, true},
 		{"load_ca_cert", Options{
-			CaCertFile: "../contrib/tls/ca.crt"}, true},
+			CaCertFile: "../contrib/tls/ca.crt",
+		}, true},
 		{"load_system_certs", Options{}, true},
 
 		// negative tests
 		{"nonexisting_client_files", Options{
 			ClientCertFile: "/nonexisting/file",
-			ClientKeyFile:  "/nonexisting/file"}, false},
+			ClientKeyFile:  "/nonexisting/file",
+		}, false},
 		{"nonexisting_ca_file", Options{
-			CaCertFile: "/nonexisting/file"}, false},
+			CaCertFile: "/nonexisting/file",
+		}, false},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			e := getTestExporterWithOptions(test.options)
+			e := getTestExporterWithOptions(t, test.options)
 
-			_, err := e.CreateClientTLSConfig("")
+			_, err := e.CreateClientTLSConfig()
 			if test.expectSuccess && err != nil {
 				t.Errorf("Expected success for test: %s, got err: %s", test.name, err)
 				return
@@ -49,9 +56,13 @@ func TestValkeyTLSScheme(t *testing.T) {
 		os.Getenv("TEST_REDIS7_TLS_URI"),
 		os.Getenv("TEST_VALKEY8_TLS_URI"),
 	} {
+		if host == "" {
+			t.Skip("Skipping test, environment variable for TLS URI not set")
+			continue
+		}
 		t.Run(host, func(t *testing.T) {
-
-			e, _ := NewRedisExporter(host,
+			e, _ := NewRedisExporter(
+				host,
 				Options{
 					SkipTLSVerification: true,
 					ClientCertFile:      "../contrib/tls/redis.crt",
@@ -92,13 +103,12 @@ func TestValkeyTLSScheme(t *testing.T) {
 					}
 				}
 			}
-
 		})
 	}
 }
 
 func TestCreateServerTLSConfig(t *testing.T) {
-	e := getTestExporter()
+	e := getTestExporter(t)
 
 	// positive tests
 	_, err := e.CreateServerTLSConfig("../contrib/tls/redis.crt", "../contrib/tls/redis.key", "", "TLS1.1")
@@ -155,4 +165,100 @@ func TestGetConfigForClientFunc(t *testing.T) {
 	if err == nil {
 		t.Errorf("Expected GetConfigForClientFunc() to fail")
 	}
+
+	cert, err := tls.LoadX509KeyPair("../contrib/tls/redis.crt", "../contrib/tls/redis.key")
+	if err != nil {
+		t.Fatalf("LoadX509KeyPair() err: %s", err)
+	}
+
+	tlsConfigSrv := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+	}
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", tlsConfigSrv)
+	if err != nil {
+		t.Fatalf("tls.Listen() err: %s", err)
+	}
+	defer ln.Close()
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				c.(*tls.Conn).Handshake() //nolint:errcheck
+				c.Close()
+			}(conn)
+		}
+	}()
+
+	serverAddr := ln.Addr().String()
+	certPath := "../contrib/tls/ca.crt"
+
+	t.Run("no-config", func(t *testing.T) {
+		e := &Exporter{
+			options: Options{
+				TlsServerName: "",
+			},
+		}
+		tlsConfig, err := e.CreateClientTLSConfig()
+		if err != nil {
+			t.Fatalf("CreateClientTLSConfig() err: %s", err)
+		}
+		if tlsConfig.ServerName != "" {
+			t.Errorf("expected empty ServerName, got %q", tlsConfig.ServerName)
+		}
+
+		// without verification and no CA, this will fail if we don't skip verification
+		if _, err = tls.Dial("tcp", serverAddr, tlsConfig); err == nil {
+			t.Errorf("expected tls.Dial() to fail")
+		}
+	})
+
+	t.Run("localhost-should-pass", func(t *testing.T) {
+		e := &Exporter{
+			options: Options{
+				TlsServerName: "localhost",
+				CaCertFile:    certPath,
+			},
+		}
+		tlsConfig, err := e.CreateClientTLSConfig()
+		if err != nil {
+			t.Fatalf("CreateClientTLSConfig() err: %s", err)
+		}
+		if tlsConfig.ServerName != "localhost" {
+			t.Errorf("expected ServerName %q, got %q", "localhost", tlsConfig.ServerName)
+		}
+
+		conn, err := tls.Dial("tcp", serverAddr, tlsConfig)
+		if err != nil {
+			t.Fatalf("tls.Dial() err: %s", err)
+		}
+		conn.Close()
+	})
+
+	t.Run("127.0.0.1-should-fail", func(t *testing.T) {
+		e := &Exporter{
+			options: Options{
+				TlsServerName: "127.0.0.1",
+				CaCertFile:    certPath,
+			},
+		}
+		tlsConfig, err := e.CreateClientTLSConfig()
+		if err != nil {
+			t.Fatalf("CreateClientTLSConfig() err: %s", err)
+		}
+		if tlsConfig.ServerName != "127.0.0.1" {
+			t.Errorf("expected ServerName %q, got %q", "127.0.0.1", tlsConfig.ServerName)
+		}
+
+		_, err = tls.Dial("tcp", serverAddr, tlsConfig)
+		if err == nil {
+			t.Fatalf("expected tls.Dial() to fail")
+		}
+		if want := "cannot validate certificate for 127.0.0.1 because it doesn't contain any IP SANs"; !strings.Contains(err.Error(), want) {
+			t.Errorf("expected err to contain %q, got: %s", want, err)
+		}
+	})
 }

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"net/http"
-	"net/url"
 	"os"
 	"os/signal"
 	"runtime"
@@ -329,11 +328,7 @@ func main() {
 	if err := validateTLSClientConfig(*tlsClientCertFile, *tlsClientKeyFile); err != nil {
 		log.Fatal(err)
 	}
-	u, err := url.Parse(*redisAddr)
-	if err != nil {
-		log.Fatalf("Couldn't parse redis addr, err: %s", err)
-	}
-	_, err = exp.CreateClientTLSConfig(u.Hostname())
+	_, err = exp.CreateClientTLSConfig()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"runtime"
@@ -328,7 +329,11 @@ func main() {
 	if err := validateTLSClientConfig(*tlsClientCertFile, *tlsClientKeyFile); err != nil {
 		log.Fatal(err)
 	}
-	_, err = exp.CreateClientTLSConfig()
+	u, err := url.Parse(*redisAddr)
+	if err != nil {
+		log.Fatalf("Couldn't parse redis addr, err: %s", err)
+	}
+	_, err = exp.CreateClientTLSConfig(u.Hostname())
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This commit enhances the service discovery for Redis/Valkey clusters, particularly for those using TLS and authentication.

Key changes:
1. The exporter now caches authentication credentials for dynamically discovered cluster nodes, allowing it to scrape metrics from clusters that require passwords.
2. The `/discover-cluster-nodes` endpoint now correctly preserves the `rediss://` or `valkeys://` scheme for TLS-enabled clusters.
3. The discovery handler can now connect to an arbitrary cluster specified by the `target` parameter, making it more flexible.
4. TLS configuration now includes the server name (SNI), improving security and compatibility.

A comprehensive set of tests has been added to validate these new capabilities, including scenarios for:
- Discovering and scraping nodes in password-protected clusters.
- Discovering and scraping nodes in TLS-enabled clusters.
- Handling different URI schemes (`redis://`, `rediss://`, `valkey://`, `valkeys://`).

Note: Depends on https://github.com/oliver006/docker-valkey-cluster/pull/1 to update the `valkey-cluster.tmpl` file used by envsubst when building the test cluster.