### PR TITLE
Allow 6 values in Keyspace parsing

### DIFF
--- a/exporter/info.go
+++ b/exporter/info.go
@@ -249,7 +249,7 @@ func parseDBKeyspaceString(inputKey string, inputVal string) (keysTotal float64,
 	}
 
 	split := strings.Split(inputVal, ",")
-	if len(split) < 2 || len(split) > 6 {
+	if len(split) < 2 {
 		log.Debugf("parseDBKeyspaceString strings.Split(inputVal) invalid: %#v", split)
 		return
 	}

--- a/exporter/info_test.go
+++ b/exporter/info_test.go
@@ -31,7 +31,7 @@ func TestKeyspaceStringParser(t *testing.T) {
 		{db: "db3", stats: "keys=123,expires=0,avg_ttl=zzz", ok: false},
 		{db: "db3", stats: "keys=1,expires=0,avg_ttl=zzz,cached_keys=0", ok: false},
 		{db: "db3", stats: "keys=1,expires=0,avg_ttl=0,cached_keys=zzz", ok: false},
-		{db: "db3", stats: "keys=1,expires=0,avg_ttl=0,cached_keys=0,extra=0", ok: false},
+		{db: "db3", stats: "keys=1,expires=0,avg_ttl=0,cached_keys=0,extra=0", keysTotal: 1, keysEx: 0, avgTTL: 0, keysCached: 0, ok: true},
 
 		{db: "db0", stats: "keys=1,expires=0,avg_ttl=0", keysTotal: 1, keysEx: 0, avgTTL: 0, keysCached: -1, ok: true},
 		{db: "db0", stats: "keys=1,expires=0,avg_ttl=0,cached_keys=0", keysTotal: 1, keysEx: 0, avgTTL: 0, keysCached: 0, ok: true},


### PR DESCRIPTION
Dragonflydb v1.35.0+ returns 6 values for each db, while redis/valkey return only 4.
Example:
```
db741:keys=55660026,expires=0,hits=602214,misses=55680191,hit_ratio=1.07,avg_ttl=-1
```