### PR TITLE
Add Sentinel metrics to improve failover detection and monitoring capabilities

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -563,6 +563,7 @@ func NewRedisExporter(uri string, opts Options) (*Exporter, error) {
 		"sentinel_master_setting_down_after_milliseconds":    {txt: "Show the current down-after-milliseconds config for each master", lbls: []string{"master_name", "master_address"}},
 		"sentinel_master_setting_failover_timeout":           {txt: "Show the current failover-timeout config for each master", lbls: []string{"master_name", "master_address"}},
 		"sentinel_master_setting_parallel_syncs":             {txt: "Show the current parallel-syncs config for each master", lbls: []string{"master_name", "master_address"}},
+		"sentinel_master_config_epoch":                       {txt: "The configuration epoch of the master (increments on each failover)", lbls: []string{"master_name", "master_address"}},
 		"sentinel_master_slaves":                             {txt: "The number of slaves of the master", lbls: []string{"master_name", "master_address"}},
 		"sentinel_master_status":                             {txt: "Master status on Sentinel", lbls: []string{"master_name", "master_address", "master_status"}},
 		"sentinel_masters":                                   {txt: "The number of masters this sentinel is watching"},

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -564,6 +564,7 @@ func NewRedisExporter(uri string, opts Options) (*Exporter, error) {
 		"sentinel_master_setting_failover_timeout":           {txt: "Show the current failover-timeout config for each master", lbls: []string{"master_name", "master_address"}},
 		"sentinel_master_setting_parallel_syncs":             {txt: "Show the current parallel-syncs config for each master", lbls: []string{"master_name", "master_address"}},
 		"sentinel_master_config_epoch":                       {txt: "The configuration epoch of the master (increments on each failover)", lbls: []string{"master_name", "master_address"}},
+		"sentinel_master_last_ok_ping_reply_ms":              {txt: "Elapsed time in milliseconds since the last successful ping reply from the master", lbls: []string{"master_name", "master_address"}},
 		"sentinel_master_slaves":                             {txt: "The number of slaves of the master", lbls: []string{"master_name", "master_address"}},
 		"sentinel_master_status":                             {txt: "Master status on Sentinel", lbls: []string{"master_name", "master_address", "master_status"}},
 		"sentinel_masters":                                   {txt: "The number of masters this sentinel is watching"},

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -564,7 +564,7 @@ func NewRedisExporter(uri string, opts Options) (*Exporter, error) {
 		"sentinel_master_setting_failover_timeout":           {txt: "Show the current failover-timeout config for each master", lbls: []string{"master_name", "master_address"}},
 		"sentinel_master_setting_parallel_syncs":             {txt: "Show the current parallel-syncs config for each master", lbls: []string{"master_name", "master_address"}},
 		"sentinel_master_config_epoch":                       {txt: "The configuration epoch of the master (increments on each failover)", lbls: []string{"master_name", "master_address"}},
-		"sentinel_master_last_ok_ping_reply_ms":              {txt: "Elapsed time in milliseconds since the last successful ping reply from the master", lbls: []string{"master_name", "master_address"}},
+		"sentinel_master_last_ok_ping_reply_seconds":         {txt: "Elapsed time in seconds since the last successful ping reply from the master", lbls: []string{"master_name", "master_address"}},
 		"sentinel_master_slaves":                             {txt: "The number of slaves of the master", lbls: []string{"master_name", "master_address"}},
 		"sentinel_master_status":                             {txt: "Master status on Sentinel", lbls: []string{"master_name", "master_address", "master_status"}},
 		"sentinel_masters":                                   {txt: "The number of masters this sentinel is watching"},

--- a/exporter/sentinels.go
+++ b/exporter/sentinels.go
@@ -81,14 +81,15 @@ func (e *Exporter) extractSentinelMetrics(ch chan<- prometheus.Metric, c redis.C
 		masterParallelSyncs, _ := strconv.ParseFloat(masterDetailMap["parallel-syncs"], 64)
 		masterDownAfterMs, _ := strconv.ParseFloat(masterDetailMap["down-after-milliseconds"], 64)
 		masterConfigEpoch, _ := strconv.ParseFloat(masterDetailMap["config-epoch"], 64)
-		masterLastOkPingReply, _ := strconv.ParseFloat(masterDetailMap["last-ok-ping-reply"], 64)
+		masterLastOkPingReplyMs, _ := strconv.ParseFloat(masterDetailMap["last-ok-ping-reply"], 64)
+		masterLastOkPingReplySeconds := masterLastOkPingReplyMs / 1000.0
 
 		e.registerConstMetricGauge(ch, "sentinel_master_setting_ckquorum", masterCkquorum, masterName, masterAddr)
 		e.registerConstMetricGauge(ch, "sentinel_master_setting_failover_timeout", masterFailoverTimeout, masterName, masterAddr)
 		e.registerConstMetricGauge(ch, "sentinel_master_setting_parallel_syncs", masterParallelSyncs, masterName, masterAddr)
 		e.registerConstMetricGauge(ch, "sentinel_master_setting_down_after_milliseconds", masterDownAfterMs, masterName, masterAddr)
 		e.registerConstMetricGauge(ch, "sentinel_master_config_epoch", masterConfigEpoch, masterName, masterAddr)
-		e.registerConstMetricGauge(ch, "sentinel_master_last_ok_ping_reply_ms", masterLastOkPingReply, masterName, masterAddr)
+		e.registerConstMetricGauge(ch, "sentinel_master_last_ok_ping_reply_seconds", masterLastOkPingReplySeconds, masterName, masterAddr)
 
 		sentinelDetails, _ := redis.Values(doRedisCmd(c, "SENTINEL", "SENTINELS", masterName))
 		log.Debugf("Sentinel details for master %s: %s", masterName, sentinelDetails)

--- a/exporter/sentinels.go
+++ b/exporter/sentinels.go
@@ -80,11 +80,13 @@ func (e *Exporter) extractSentinelMetrics(ch chan<- prometheus.Metric, c redis.C
 		masterFailoverTimeout, _ := strconv.ParseFloat(masterDetailMap["failover-timeout"], 64)
 		masterParallelSyncs, _ := strconv.ParseFloat(masterDetailMap["parallel-syncs"], 64)
 		masterDownAfterMs, _ := strconv.ParseFloat(masterDetailMap["down-after-milliseconds"], 64)
+		masterConfigEpoch, _ := strconv.ParseFloat(masterDetailMap["config-epoch"], 64)
 
 		e.registerConstMetricGauge(ch, "sentinel_master_setting_ckquorum", masterCkquorum, masterName, masterAddr)
 		e.registerConstMetricGauge(ch, "sentinel_master_setting_failover_timeout", masterFailoverTimeout, masterName, masterAddr)
 		e.registerConstMetricGauge(ch, "sentinel_master_setting_parallel_syncs", masterParallelSyncs, masterName, masterAddr)
 		e.registerConstMetricGauge(ch, "sentinel_master_setting_down_after_milliseconds", masterDownAfterMs, masterName, masterAddr)
+		e.registerConstMetricGauge(ch, "sentinel_master_config_epoch", masterConfigEpoch, masterName, masterAddr)
 
 		sentinelDetails, _ := redis.Values(doRedisCmd(c, "SENTINEL", "SENTINELS", masterName))
 		log.Debugf("Sentinel details for master %s: %s", masterName, sentinelDetails)

--- a/exporter/sentinels.go
+++ b/exporter/sentinels.go
@@ -81,12 +81,14 @@ func (e *Exporter) extractSentinelMetrics(ch chan<- prometheus.Metric, c redis.C
 		masterParallelSyncs, _ := strconv.ParseFloat(masterDetailMap["parallel-syncs"], 64)
 		masterDownAfterMs, _ := strconv.ParseFloat(masterDetailMap["down-after-milliseconds"], 64)
 		masterConfigEpoch, _ := strconv.ParseFloat(masterDetailMap["config-epoch"], 64)
+		masterLastOkPingReply, _ := strconv.ParseFloat(masterDetailMap["last-ok-ping-reply"], 64)
 
 		e.registerConstMetricGauge(ch, "sentinel_master_setting_ckquorum", masterCkquorum, masterName, masterAddr)
 		e.registerConstMetricGauge(ch, "sentinel_master_setting_failover_timeout", masterFailoverTimeout, masterName, masterAddr)
 		e.registerConstMetricGauge(ch, "sentinel_master_setting_parallel_syncs", masterParallelSyncs, masterName, masterAddr)
 		e.registerConstMetricGauge(ch, "sentinel_master_setting_down_after_milliseconds", masterDownAfterMs, masterName, masterAddr)
 		e.registerConstMetricGauge(ch, "sentinel_master_config_epoch", masterConfigEpoch, masterName, masterAddr)
+		e.registerConstMetricGauge(ch, "sentinel_master_last_ok_ping_reply_ms", masterLastOkPingReply, masterName, masterAddr)
 
 		sentinelDetails, _ := redis.Values(doRedisCmd(c, "SENTINEL", "SENTINELS", masterName))
 		log.Debugf("Sentinel details for master %s: %s", masterName, sentinelDetails)


### PR DESCRIPTION
**New Metrics**
1. sentinel_master_config_epoch: The configuration epoch of the master (increments on each failover)
   - Extracted from `SENTINEL MASTERS` command response
   - Labels: `master_name`, `master_address`
   - Use case: Track failover events and frequency

2. sentinel_master_last_ok_ping_reply_ms: Elapsed time in milliseconds since the last successful ping reply
   - Extracted from `SENTINEL MASTERS` command response  
   - Labels: `master_name`, `master_address`
   - Use case: Monitor master health and detect potential down states proactively

**Changes**
- Added `config-epoch` field extraction in `extractSentinelMetrics()` function
- Added `last-ok-ping-reply` field extraction in `extractSentinelMetrics()` function
- Added metric descriptions in `exporter.go`

closes: #1077 