### PR TITLE
chore: update Go version from 1.25.0 to 1.25.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oliver006/redis_exporter
 
-go 1.25.0
+go 1.25.5
 
 require (
 	github.com/gomodule/redigo v1.9.3


### PR DESCRIPTION
[Version 1.25.5](https://github.com/golang/go/issues?q=milestone%3AGo1.25.5+label%3ACherryPickApproved) contains two security fixes to the crypto/x509 package and other fixes.

I would appreciate a release with this change.