### PR TITLE
chore: update Go version from 1.25.0 to 1.25.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG ALPINE_VERSION=3.23
 #
 # build container
 #
-FROM --platform=$BUILDPLATFORM golang:1.25.5-alpine${ALPINE_VERSION} AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine${ALPINE_VERSION} AS builder
 WORKDIR /go/src/github.com/oliver006/redis_exporter/
 
 ADD . /go/src/github.com/oliver006/redis_exporter/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oliver006/redis_exporter
 
-go 1.25.5
+go 1.25
 
 require (
 	github.com/gomodule/redigo v1.9.3


### PR DESCRIPTION
[Version 1.25.5](https://github.com/golang/go/issues?q=milestone%3AGo1.25.5+label%3ACherryPickApproved) contains two security fixes to the crypto/x509 package and other fixes.

I would appreciate a release with this change.

Previous PR with this change had to be closed: https://github.com/oliver006/redis_exporter/pull/1079
Organization policy require all OSS commits coming from Snowflake-Labs github org.