### PR TITLE
docs: add Docker Compose production example with Prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,18 @@ redis_exporter container can access it:
 docker run -d --name redis_exporter --network host oliver006/redis_exporter
 ```
 
+### Docker Compose Production Example
+
+For a complete monitoring stack with Redis, Redis Exporter, and Prometheus, see [docker-compose-production.yml](contrib/docker-compose-production.yml).
+
+Quick start:
+```sh
+cd contrib
+# Create .env file with your Redis password
+echo "REDIS_PASSWORD=your-secure-password" > .env
+docker-compose -f docker-compose-production.yml up -d
+```
+
 ### Run on Kubernetes
 
 [Here](contrib/k8s-redis-and-exporter-deployment.yaml) is an example Kubernetes deployment configuration for how to deploy the redis_exporter as a sidecar to a Redis instance.

--- a/contrib/docker-compose-production.yml
+++ b/contrib/docker-compose-production.yml
@@ -1,0 +1,67 @@
+# Production Docker Compose example for Redis Exporter with Prometheus
+# This setup provides a complete monitoring stack for Redis/Valkey
+
+services:
+  # Redis instance (replace with your production Redis)
+  redis:
+    image: redis:7
+    command: redis-server --requirepass ${REDIS_PASSWORD:-your-redis-password}
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD:-your-redis-password}", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  # Redis Exporter
+  redis-exporter:
+    image: oliver006/redis_exporter:latest
+    environment:
+      - REDIS_ADDR=redis://redis:6379
+      - REDIS_PASSWORD=${REDIS_PASSWORD:-your-redis-password}
+      # Optional: Enable debug mode
+      # - REDIS_EXPORTER_DEBUG=true
+      # Optional: Check specific keys
+      # - REDIS_EXPORTER_CHECK_KEYS=user:*,session:*
+    ports:
+      - "9121:9121"
+    depends_on:
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+
+  # Prometheus (optional - for complete monitoring stack)
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    ports:
+      - "9090:9090"
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.enable-lifecycle'
+    depends_on:
+      - redis-exporter
+    restart: unless-stopped
+
+volumes:
+  redis-data:
+  prometheus-data:
+
+# Usage:
+#   1. Create a .env file with REDIS_PASSWORD=your-secure-password
+#   2. Create prometheus.yml (see example below)
+#   3. Run: docker-compose -f docker-compose-production.yml up -d
+#
+# Example prometheus.yml:
+#   global:
+#     scrape_interval: 15s
+#   scrape_configs:
+#     - job_name: 'redis'
+#       static_configs:
+#         - targets: ['redis-exporter:9121']


### PR DESCRIPTION
## Summary

This PR adds a production-ready Docker Compose example that includes:

- Redis instance with password authentication
- Redis Exporter with proper configuration
- Prometheus for metrics collection
- Health checks and service dependencies
- Environment variable configuration

## Changes

- Added `contrib/docker-compose-production.yml` with a complete monitoring stack
- Updated `README.md` with reference to the new example and quick start guide

## Motivation

The existing `docker-compose.yml` is focused on testing. This addition provides users with a ready-to-use production example that demonstrates best practices for deploying Redis Exporter with Prometheus.

## Testing

Tested locally with Docker Compose v2.