### PR TITLE
feat: add rdb_current_file_size_bytes metric

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -593,6 +593,7 @@ func NewRedisExporter(uri string, opts Options) (*Exporter, error) {
 		"slave_repl_offset":                                  {txt: "Slave replication offset", lbls: []string{"master_host", "master_port"}},
 		"slowlog_last_id":                                    {txt: `Last id of slowlog`},
 		"slowlog_length":                                     {txt: `Total slowlog`},
+		"rdb_current_file_size_bytes":                        {txt: "Current size of the RDB file in bytes"},
 		"start_time_seconds":                                 {txt: "Start time of the Redis instance since unix epoch in seconds."},
 		"stream_first_entry_id":                              {txt: `The epoch timestamp (ms) of the first message in the stream`, lbls: []string{"db", "stream"}},
 		"stream_group_consumer_idle_seconds":                 {txt: `Consumer idle time in seconds`, lbls: []string{"db", "stream", "group", "consumer"}},
@@ -810,15 +811,18 @@ func (e *Exporter) scrapeRedisHost(ch chan<- prometheus.Metric) error {
 	}
 
 	dbCount := 0
+	config := map[string]string{}
 	if e.options.ConfigCommandName == "-" {
 		log.Debugf("Skipping extractConfigMetrics()")
 	} else {
-		if config, err := redis.StringMap(doRedisCmd(c, e.options.ConfigCommandName, "GET", "*")); err == nil {
+		if config, err = redis.StringMap(doRedisCmd(c, e.options.ConfigCommandName, "GET", "*")); err == nil {
 			dbCount, err = e.extractConfigMetrics(ch, config)
 			if err != nil {
 				log.Errorf("Redis extractConfigMetrics() err: %s", err)
 				return err
 			}
+			// Extract RDB file size metric using the config
+			e.extractRDBFileSizeMetrics(ch, config)
 		} else {
 			log.Debugf("Redis CONFIG err: %s", err)
 		}

--- a/exporter/rdb_file_size.go
+++ b/exporter/rdb_file_size.go
@@ -1,0 +1,45 @@
+package exporter
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+)
+
+// extractRDBFileSizeMetrics extracts the current RDB file size metric
+// by combining the dir and dbfilename config values and stat'ing the file
+func (e *Exporter) extractRDBFileSizeMetrics(ch chan<- prometheus.Metric, config map[string]string) {
+	// Get the RDB file path components from config
+	dir, hasDir := config["dir"]
+	dbFilename, hasDbFilename := config["dbfilename"]
+
+	if !hasDir || !hasDbFilename {
+		log.Debugf("Cannot extract RDB file size: missing dir=%v or dbfilename=%v", hasDir, hasDbFilename)
+		return
+	}
+
+	// Construct the full path to the RDB file
+	// Handle the case where dir might be relative or absolute
+	rdbPath := filepath.Join(dir, dbFilename)
+
+	// Check if the file exists and get its size
+	fileInfo, err := os.Stat(rdbPath)
+	if err != nil {
+		// File might not exist during initial startup or if RDB persistence is disabled
+		log.Debugf("Could not stat RDB file at %s: %v", rdbPath, err)
+		return
+	}
+
+	if fileInfo.IsDir() {
+		log.Debugf("RDB path %s is a directory, not a file", rdbPath)
+		return
+	}
+
+	// Register the RDB file size metric
+	fileSize := float64(fileInfo.Size())
+	e.registerConstMetricGauge(ch, "rdb_current_file_size_bytes", fileSize)
+	log.Debugf("RDB file size metric: %s = %d bytes", rdbPath, fileInfo.Size())
+}

--- a/exporter/rdb_file_size_test.go
+++ b/exporter/rdb_file_size_test.go
@@ -1,0 +1,95 @@
+package exporter
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestExtractRDBFileSizeMetrics(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+
+	// Create a mock RDB file
+	rdbFile := filepath.Join(tempDir, "dump.rdb")
+	expectedSize := int64(1024)
+	if err := os.WriteFile(rdbFile, make([]byte, expectedSize), 0644); err != nil {
+		t.Fatalf("Failed to create mock RDB file: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		config     map[string]string
+		expectSize bool
+	}{
+		{
+			name: "valid config with RDB file",
+			config: map[string]string{
+				"dir":        tempDir,
+				"dbfilename": "dump.rdb",
+			},
+			expectSize: true,
+		},
+		{
+			name: "missing dir config",
+			config: map[string]string{
+				"dbfilename": "dump.rdb",
+			},
+			expectSize: false,
+		},
+		{
+			name: "missing dbfilename config",
+			config: map[string]string{
+				"dir": tempDir,
+			},
+			expectSize: false,
+		},
+		{
+			name: "non-existent RDB file",
+			config: map[string]string{
+				"dir":        tempDir,
+				"dbfilename": "nonexistent.rdb",
+			},
+			expectSize: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &Exporter{}
+			ch := make(chan prometheus.Metric, 1)
+
+			e.extractRDBFileSizeMetrics(ch, tt.config)
+
+			if tt.expectSize {
+				select {
+				case metric := <-ch:
+					desc := metric.Desc().String()
+					if !containsSubstring(desc, "rdb_current_file_size_bytes") {
+						t.Errorf("Expected rdb_current_file_size_bytes metric, got: %s", desc)
+					}
+				default:
+					t.Error("Expected a metric but got none")
+				}
+			} else {
+				select {
+				case <-ch:
+					t.Error("Expected no metric but got one")
+				default:
+					// This is expected - no metric should be produced
+				}
+			}
+		})
+	}
+}
+
+func containsSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This PR implements support for exposing the current RDB file size as a Prometheus metric.

## Changes
- Added new metric `rdb_current_file_size_bytes` that reports the current size of the RDB file on disk
- Implemented `extractRDBFileSizeMetrics()` function that reads the RDB file path from Redis config and stats the file
- Added comprehensive unit tests

## Why This Is Useful
- Storage capacity planning - track RDB growth over time
- Detect abnormal RDB expansion
- Correlate RDB size with memory usage

Fixes #1093

Thanks to @akshaykumar-vijapur for the proposal! 🙏