### PR TITLE
fix: guard empty percentile key in extractPercentileVal to prevent panic

### DIFF
--- a/exporter/info.go
+++ b/exporter/info.go
@@ -57,6 +57,10 @@ func extractPercentileVal(s string) (percentile float64, val float64, err error)
 	if len(split) != 2 {
 		return
 	}
+	if len(split[0]) == 0 {
+		err = fmt.Errorf("empty percentile key")
+		return
+	}
 	percentile, err = strconv.ParseFloat(split[0][1:], 64)
 	if err != nil {
 		return

--- a/exporter/info_test.go
+++ b/exporter/info_test.go
@@ -504,6 +504,13 @@ func Test_parseMetricsLatencyStats(t *testing.T) {
 			wantPercentileMap: map[float64]float64{},
 			wantErr:           true,
 		},
+		{
+			name:              "empty-percentile-key",
+			args:              args{fieldKey: "latency_percentiles_usec_ping", fieldValue: "=1.0,p99=2.0"},
+			wantCmd:           "ping",
+			wantPercentileMap: map[float64]float64{},
+			wantErr:           true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
A `latency_percentiles_usec_*` line with an empty key segment (leading `=`, e.g. `=1.0,p99=2.0`) splits to `["", "1.0"]` and `split[0][1:]` panics with index out of range. The panic propagates through promhttp and exits the process, so under `restart: always` one malformed `INFO` reply becomes a restart loop.

Adds a length check before the slice and returns an error so the existing caller (`parseMetricsLatencyStats`) records the parse failure and moves on. Test case added covering the empty-key input.

Refs #1115.