### PR TITLE
feat: expose repl-backlog-size config at config_repl_backlog_size

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -723,9 +723,10 @@ func (e *Exporter) extractConfigMetrics(ch chan<- prometheus.Metric, config map[
 		}
 
 		if map[string]bool{
-			"io-threads": true,
-			"maxclients": true,
-			"maxmemory":  true,
+			"io-threads":        true,
+			"maxclients":        true,
+			"maxmemory":         true,
+			"repl-backlog-size": true,
 		}[strKey] {
 			if val, err := strconv.ParseFloat(strVal, 64); err == nil {
 				strKey = strings.ReplaceAll(strKey, "-", "_")

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -376,6 +376,19 @@ func TestClientOutputBufferLimitMetrics(t *testing.T) {
 	}
 }
 
+func TestConfigReplBacklogSizeMetric(t *testing.T) {
+	e := getTestExporter()
+	ts := httptest.NewServer(e)
+	defer ts.Close()
+
+	body := downloadURL(t, ts.URL+"/metrics")
+
+	want := "test_config_repl_backlog_size "
+	if !strings.Contains(body, want) {
+		t.Errorf("want metrics to include %s, have:\n%s", want, body)
+	}
+}
+
 func TestExcludeConfigMetricsViaCONFIGCommand(t *testing.T) {
 	for _, inc := range []bool{false, true} {
 		e, _ := NewRedisExporter(os.Getenv("TEST_REDIS_URI"),


### PR DESCRIPTION
Exposes the `repl-backlog-size` config at `config_repl_backlog_size`.

