### PR TITLE
Add SBOM generation to docker image release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,7 @@ jobs:
           target: scratch-release
           platforms: linux/amd64,linux/arm,linux/arm64
           push: true
+          sbom: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |


### PR DESCRIPTION
Hey :)
First of all wanted to thank you for that project!

I am using it in my environment and our security teams started requiring docker images to use SBOMs to validate CVEs, since it is very easy to change the docker build process to include a SBOM, I would highly appreciate it if you could approve it and then I will be able to keep using this in our environment.

Thank you in advance!