### PR TITLE
test: skip instead of panic when TEST_REDIS_URI is unset

### DIFF
--- a/exporter/clients_test.go
+++ b/exporter/clients_test.go
@@ -144,7 +144,7 @@ func TestParseClientListString(t *testing.T) {
 
 func TestExportClientList(t *testing.T) {
 	for _, isExportClientList := range []bool{true, false} {
-		e := getTestExporterWithOptions(Options{
+		e := getTestExporterWithOptions(t, Options{
 			Namespace:        "test",
 			ExportClientList: isExportClientList,
 		})
@@ -241,7 +241,7 @@ func TestExportClientListRedis7(t *testing.T) {
 
 func TestExportClientListInclPort(t *testing.T) {
 	for _, inclPort := range []bool{true, false} {
-		e := getTestExporterWithOptions(Options{
+		e := getTestExporterWithOptions(t, Options{
 			Namespace:             "test",
 			ExportClientList:      true,
 			ExportClientsInclPort: inclPort,

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -66,14 +66,14 @@ var (
 	TestKeyNameHll          = "test-hll"
 )
 
-func getTestExporter() *Exporter {
-	return getTestExporterWithOptions(Options{Namespace: "test"})
+func getTestExporter(t *testing.T) *Exporter {
+	return getTestExporterWithOptions(t, Options{Namespace: "test"})
 }
 
-func getTestExporterWithOptions(opt Options) *Exporter {
+func getTestExporterWithOptions(t *testing.T, opt Options) *Exporter {
 	addr := os.Getenv("TEST_REDIS_URI")
 	if addr == "" {
-		panic("missing env var TEST_REDIS_URI")
+		t.Skip("missing env var TEST_REDIS_URI")
 	}
 	e, _ := NewRedisExporter(addr, opt)
 	return e
@@ -383,7 +383,7 @@ func TestClientOutputBufferLimitMetrics(t *testing.T) {
 }
 
 func TestConfigReplBacklogSizeMetric(t *testing.T) {
-	e := getTestExporter()
+	e := getTestExporter(t)
 	ts := httptest.NewServer(e)
 	defer ts.Close()
 

--- a/exporter/latency_test.go
+++ b/exporter/latency_test.go
@@ -18,7 +18,7 @@ const (
 )
 
 func TestLatencySpike(t *testing.T) {
-	e := getTestExporter()
+	e := getTestExporter(t)
 
 	setupLatency(t, os.Getenv("TEST_REDIS_URI"))
 	defer resetLatency(t, os.Getenv("TEST_REDIS_URI"))

--- a/exporter/metrics_test.go
+++ b/exporter/metrics_test.go
@@ -23,7 +23,7 @@ func TestSanitizeMetricName(t *testing.T) {
 func TestRegisterConstHistogram(t *testing.T) {
 	metricName := "foo"
 	for _, inc := range []bool{false, true} {
-		exp := getTestExporterWithOptions(Options{Namespace: "test", AppendInstanceRoleLabel: inc})
+		exp := getTestExporterWithOptions(t, Options{Namespace: "test", AppendInstanceRoleLabel: inc})
 		ch := make(chan prometheus.Metric)
 		go func() {
 			exp.createMetricDescription(metricName, []string{"test"})
@@ -49,7 +49,7 @@ func TestRegisterConstHistogram(t *testing.T) {
 func TestRegisterConstMetric(t *testing.T) {
 	metricName := "bar"
 	for _, inc := range []bool{false, true} {
-		exp := getTestExporterWithOptions(Options{Namespace: "test", AppendInstanceRoleLabel: inc})
+		exp := getTestExporterWithOptions(t, Options{Namespace: "test", AppendInstanceRoleLabel: inc})
 		ch := make(chan prometheus.Metric)
 		go func() {
 			exp.createMetricDescription(metricName, []string{"test"})
@@ -73,7 +73,7 @@ func TestRegisterConstMetric(t *testing.T) {
 }
 
 func TestFindOrCreateMetricsDescriptionFindExisting(t *testing.T) {
-	exp := getTestExporter()
+	exp := getTestExporter(t)
 	exp.metricDescriptions = map[string]*prometheus.Desc{}
 
 	metricName := "foo"
@@ -92,7 +92,7 @@ func TestFindOrCreateMetricsDescriptionFindExisting(t *testing.T) {
 }
 
 func TestFindOrCreateMetricsDescriptionCreateNew(t *testing.T) {
-	exp := getTestExporter()
+	exp := getTestExporter(t)
 	exp.metricDescriptions = map[string]*prometheus.Desc{}
 
 	metricName := "foo"

--- a/exporter/slowlog_test.go
+++ b/exporter/slowlog_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestSlowLog(t *testing.T) {
-	e := getTestExporter()
+	e := getTestExporter(t)
 
 	chM := make(chan prometheus.Metric)
 	go func() {


### PR DESCRIPTION
## What

`getTestExporter` / `getTestExporterWithOptions` now take `*testing.T` and call `t.Skip` when `TEST_REDIS_URI` is unset, instead of `panic`. The suite then skips cleanly on machines without a live Redis rather than crashing the package.

No change to non-test code.

## Why

Splitting out a small, mechanical, behaviour-preserving change so the two feature PRs that follow are easier to review.