### PR TITLE
fix: prevent exporter crash on invalid RediSearch index regex

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -125,6 +126,12 @@ func NewRedisExporter(uri string, opts Options) (*Exporter, error) {
 	}
 
 	log.Debugf("NewRedisExporter = using redis uri: %s", uri)
+
+	if opts.InclSearchIndexesMetrics {
+		if _, err := regexp.Compile(opts.CheckSearchIndexes); err != nil {
+			return nil, fmt.Errorf("invalid check-search-indexes regex %q: %w", opts.CheckSearchIndexes, err)
+		}
+	}
 
 	if opts.Registry == nil {
 		opts.Registry = prometheus.NewRegistry()

--- a/exporter/search_indexes.go
+++ b/exporter/search_indexes.go
@@ -47,11 +47,7 @@ func (e *Exporter) extractSearchIndexesMetrics(ch chan<- prometheus.Metric, c re
 	}
 
 	// Get indexes list based on check-search-indexes regex
-	checkIndexRegex, err := regexp.Compile(e.options.CheckSearchIndexes)
-	if err != nil {
-		log.Errorf("invalid check-search-indexes regex %q: %s", e.options.CheckSearchIndexes, err)
-		return
-	}
+	checkIndexRegex := regexp.MustCompile(e.options.CheckSearchIndexes)
 	for _, index := range allSearchIndexes {
 		if checkIndexRegex.MatchString(index) {
 			searchIndexes = append(searchIndexes, index)

--- a/exporter/search_indexes.go
+++ b/exporter/search_indexes.go
@@ -47,7 +47,11 @@ func (e *Exporter) extractSearchIndexesMetrics(ch chan<- prometheus.Metric, c re
 	}
 
 	// Get indexes list based on check-search-indexes regex
-	checkIndexRegex := regexp.MustCompile(e.options.CheckSearchIndexes)
+	checkIndexRegex, err := regexp.Compile(e.options.CheckSearchIndexes)
+	if err != nil {
+		log.Errorf("invalid check-search-indexes regex %q: %s", e.options.CheckSearchIndexes, err)
+		return
+	}
 	for _, index := range allSearchIndexes {
 		if checkIndexRegex.MatchString(index) {
 			searchIndexes = append(searchIndexes, index)

--- a/exporter/search_indexes_test.go
+++ b/exporter/search_indexes_test.go
@@ -110,24 +110,26 @@ func TestExtractSearchIndexesMetrics(t *testing.T) {
 	}
 }
 
-func TestNewRedisExporterInvalidSearchIndexRegex(t *testing.T) {
-	_, err := NewRedisExporter("", Options{
-		Namespace:                "test",
-		InclSearchIndexesMetrics: true,
-		CheckSearchIndexes:       "[",
-	})
-	if err == nil {
-		t.Fatal("expected invalid check-search-indexes regex to fail at startup")
+func TestNewRedisExporterSearchIndexRegex(t *testing.T) {
+	tests := []struct {
+		name    string
+		regex   string
+		wantErr bool
+	}{
+		{name: "valid", regex: "^idx:", wantErr: false},
+		{name: "invalid", regex: "[", wantErr: true},
 	}
-}
 
-func TestNewRedisExporterValidSearchIndexRegex(t *testing.T) {
-	_, err := NewRedisExporter("", Options{
-		Namespace:                "test",
-		InclSearchIndexesMetrics: true,
-		CheckSearchIndexes:       "^idx:",
-	})
-	if err != nil {
-		t.Fatalf("expected valid check-search-indexes regex to succeed: %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewRedisExporter("", Options{
+				Namespace:                "test",
+				InclSearchIndexesMetrics: true,
+				CheckSearchIndexes:       tt.regex,
+			})
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewRedisExporter() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
 	}
 }

--- a/exporter/search_indexes_test.go
+++ b/exporter/search_indexes_test.go
@@ -4,11 +4,24 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gomodule/redigo/redis"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 )
+
+type searchIndexListConn struct{}
+
+func (searchIndexListConn) Close() error                   { return nil }
+func (searchIndexListConn) Err() error                     { return nil }
+func (searchIndexListConn) Flush() error                   { return nil }
+func (searchIndexListConn) Receive() (any, error)          { return nil, nil }
+func (searchIndexListConn) Send(string, ...any) error      { return nil }
+func (searchIndexListConn) Do(string, ...any) (any, error) { return []any{[]byte("idx")}, nil }
+func (searchIndexListConn) ReceiveWithTimeout(time.Duration) (any, error) {
+	return nil, nil
+}
 
 func setupSearchIndex(t *testing.T, addr string) error {
 	c, err := redis.DialURL(addr)
@@ -108,4 +121,16 @@ func TestExtractSearchIndexesMetrics(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestExtractSearchIndexesMetricsInvalidRegexDoesNotPanic(t *testing.T) {
+	e, _ := NewRedisExporter("", Options{Namespace: "test", CheckSearchIndexes: "["})
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("invalid check-search-indexes regex should be logged and skipped, got panic: %v", r)
+		}
+	}()
+
+	e.extractSearchIndexesMetrics(make(chan prometheus.Metric), searchIndexListConn{})
 }

--- a/exporter/search_indexes_test.go
+++ b/exporter/search_indexes_test.go
@@ -4,24 +4,11 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/gomodule/redigo/redis"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 )
-
-type searchIndexListConn struct{}
-
-func (searchIndexListConn) Close() error                   { return nil }
-func (searchIndexListConn) Err() error                     { return nil }
-func (searchIndexListConn) Flush() error                   { return nil }
-func (searchIndexListConn) Receive() (any, error)          { return nil, nil }
-func (searchIndexListConn) Send(string, ...any) error      { return nil }
-func (searchIndexListConn) Do(string, ...any) (any, error) { return []any{[]byte("idx")}, nil }
-func (searchIndexListConn) ReceiveWithTimeout(time.Duration) (any, error) {
-	return nil, nil
-}
 
 func setupSearchIndex(t *testing.T, addr string) error {
 	c, err := redis.DialURL(addr)
@@ -123,14 +110,13 @@ func TestExtractSearchIndexesMetrics(t *testing.T) {
 	}
 }
 
-func TestExtractSearchIndexesMetricsInvalidRegexDoesNotPanic(t *testing.T) {
-	e, _ := NewRedisExporter("", Options{Namespace: "test", CheckSearchIndexes: "["})
-
-	defer func() {
-		if r := recover(); r != nil {
-			t.Fatalf("invalid check-search-indexes regex should be logged and skipped, got panic: %v", r)
-		}
-	}()
-
-	e.extractSearchIndexesMetrics(make(chan prometheus.Metric), searchIndexListConn{})
+func TestNewRedisExporterInvalidSearchIndexRegex(t *testing.T) {
+	_, err := NewRedisExporter("", Options{
+		Namespace:                "test",
+		InclSearchIndexesMetrics: true,
+		CheckSearchIndexes:       "[",
+	})
+	if err == nil {
+		t.Fatal("expected invalid check-search-indexes regex to fail at startup")
+	}
 }

--- a/exporter/search_indexes_test.go
+++ b/exporter/search_indexes_test.go
@@ -120,3 +120,14 @@ func TestNewRedisExporterInvalidSearchIndexRegex(t *testing.T) {
 		t.Fatal("expected invalid check-search-indexes regex to fail at startup")
 	}
 }
+
+func TestNewRedisExporterValidSearchIndexRegex(t *testing.T) {
+	_, err := NewRedisExporter("", Options{
+		Namespace:                "test",
+		InclSearchIndexesMetrics: true,
+		CheckSearchIndexes:       "^idx:",
+	})
+	if err != nil {
+		t.Fatalf("expected valid check-search-indexes regex to succeed: %v", err)
+	}
+}


### PR DESCRIPTION
## Changes

- Replace `regexp.MustCompile(e.options.CheckSearchIndexes)` with `regexp.Compile`
- Log and skip RediSearch index metrics when `--check-search-indexes` contains an invalid regex
- Add a regression test covering invalid regex input without panic