### PR TITLE
ensure a change in label keys doesn't vanish the metric

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -38,6 +38,8 @@ type Exporter struct {
 	targetScrapeRequestErrors prometheus.Counter
 
 	metricDescriptions map[string]*prometheus.Desc
+	// labels each cached description was built with, to detect runtime changes
+	metricDescriptionLabels map[string][]string
 
 	options Options
 
@@ -515,6 +517,7 @@ func NewRedisExporter(uri string, opts Options) (*Exporter, error) {
 	}
 
 	e.metricDescriptions = map[string]*prometheus.Desc{}
+	e.metricDescriptionLabels = map[string][]string{}
 
 	for k, desc := range map[string]struct {
 		txt  string
@@ -636,6 +639,7 @@ func NewRedisExporter(uri string, opts Options) (*Exporter, error) {
 			desc.lbls = append(desc.lbls, "instance_role") // append instance_role label to all metrics
 		}
 		e.metricDescriptions[k] = newMetricDescr(opts.Namespace, k, desc.txt, desc.lbls)
+		e.metricDescriptionLabels[k] = desc.lbls
 	}
 
 	if e.options.MetricsPath == "" {

--- a/exporter/info_test.go
+++ b/exporter/info_test.go
@@ -536,12 +536,15 @@ func TestInstanceInfoLabelsChangeBetweenScrapes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRedisExporter() err: %s", err)
 	}
+	// force the lazy init of metricDescriptionLabels on the first scrape
+	e.metricDescriptionLabels = nil
 
 	// Valkey 8.0 has no valkey_release_stage field
 	infoBefore := "# Server\r\nredis_version:7.2.5\r\nredis_mode:standalone\r\nrun_id:abc\r\nvalkey_version:8.0.0\r\n"
 	// Valkey 8.1 added valkey_release_stage
 	infoAfter := "# Server\r\nredis_version:7.2.5\r\nredis_mode:standalone\r\nrun_id:abc\r\nvalkey_version:8.1.0\r\nvalkey_release_stage:ga\r\n"
 
+	descs := make([]string, 2)
 	for i, info := range []string{infoBefore, infoAfter} {
 		ch := make(chan prometheus.Metric)
 		go func() {
@@ -549,14 +552,27 @@ func TestInstanceInfoLabelsChangeBetweenScrapes(t *testing.T) {
 			close(ch)
 		}()
 
-		found := false
 		for m := range ch {
 			if strings.Contains(m.Desc().String(), "test_instance_info") {
-				found = true
+				descs[i] = m.Desc().String()
 			}
 		}
-		if !found {
+		if descs[i] == "" {
 			t.Fatalf("scrape %d: test_instance_info metric missing after the instance_info label set changed", i)
 		}
+	}
+
+	// the description must be rebuilt with the new label set, not the stale cached one
+	if strings.Contains(descs[0], "valkey_release_stage") {
+		t.Errorf("first scrape unexpectedly exposed valkey_release_stage label:\n%s", descs[0])
+	}
+	if !strings.Contains(descs[1], "valkey_release_stage") {
+		t.Errorf("second scrape missing new valkey_release_stage label after the upgrade:\n%s", descs[1])
+	}
+
+	// a metric with no explicit labels must always return the cached description
+	noLabel := e.createMetricDescription("uptime_in_seconds", nil)
+	if noLabel != e.createMetricDescription("uptime_in_seconds", nil) {
+		t.Errorf("expected cached description to be reused for a metric without labels")
 	}
 }

--- a/exporter/info_test.go
+++ b/exporter/info_test.go
@@ -528,3 +528,35 @@ func Test_parseMetricsLatencyStats(t *testing.T) {
 		})
 	}
 }
+
+// instance_info must survive a Valkey 8.0 -> 8.1 upgrade that adds the new
+// valkey_release_stage INFO field between scrapes, without a restart.
+func TestInstanceInfoLabelsChangeBetweenScrapes(t *testing.T) {
+	e, err := NewRedisExporter("redis://localhost:6379", Options{Namespace: "test"})
+	if err != nil {
+		t.Fatalf("NewRedisExporter() err: %s", err)
+	}
+
+	// Valkey 8.0 has no valkey_release_stage field
+	infoBefore := "# Server\r\nredis_version:7.2.5\r\nredis_mode:standalone\r\nrun_id:abc\r\nvalkey_version:8.0.0\r\n"
+	// Valkey 8.1 added valkey_release_stage
+	infoAfter := "# Server\r\nredis_version:7.2.5\r\nredis_mode:standalone\r\nrun_id:abc\r\nvalkey_version:8.1.0\r\nvalkey_release_stage:ga\r\n"
+
+	for i, info := range []string{infoBefore, infoAfter} {
+		ch := make(chan prometheus.Metric)
+		go func() {
+			e.extractInfoMetrics(ch, info, 0)
+			close(ch)
+		}()
+
+		found := false
+		for m := range ch {
+			if strings.Contains(m.Desc().String(), "test_instance_info") {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("scrape %d: test_instance_info metric missing after the instance_info label set changed", i)
+		}
+	}
+}

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -3,6 +3,7 @@ package exporter
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -152,13 +153,24 @@ func (e *Exporter) mustFindMetricDescription(metricName string) *prometheus.Desc
 }
 
 func (e *Exporter) createMetricDescription(metricName string, labels []string) *prometheus.Desc {
-	if desc, found := e.metricDescriptions[metricName]; found {
-		return desc
-	}
+	explicitLabels := len(labels) > 0
+
 	if e.options.AppendInstanceRoleLabel && metricName != "exporter_last_scrape_connect_time_seconds" && metricName != "exporter_last_scrape_ping_time_seconds" {
 		labels = append(labels, "instance_role") // append instance_role label to all metrics (except 2 collected before instanceRole)
 	}
+
+	if desc, found := e.metricDescriptions[metricName]; found {
+		// rebuild when a dynamic-label metric (e.g. instance_info) changes its labels at runtime, e.g. a Valkey upgrade adding new INFO fields
+		if !explicitLabels || slices.Equal(e.metricDescriptionLabels[metricName], labels) {
+			return desc
+		}
+	}
+
+	if e.metricDescriptionLabels == nil {
+		e.metricDescriptionLabels = map[string][]string{}
+	}
 	d := newMetricDescr(e.options.Namespace, metricName, metricName+" metric", labels)
 	e.metricDescriptions[metricName] = d
+	e.metricDescriptionLabels[metricName] = labels
 	return d
 }

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -153,15 +153,13 @@ func (e *Exporter) mustFindMetricDescription(metricName string) *prometheus.Desc
 }
 
 func (e *Exporter) createMetricDescription(metricName string, labels []string) *prometheus.Desc {
-	explicitLabels := len(labels) > 0
-
 	if e.options.AppendInstanceRoleLabel && metricName != "exporter_last_scrape_connect_time_seconds" && metricName != "exporter_last_scrape_ping_time_seconds" {
 		labels = append(labels, "instance_role") // append instance_role label to all metrics (except 2 collected before instanceRole)
 	}
 
 	if desc, found := e.metricDescriptions[metricName]; found {
-		// rebuild when a dynamic-label metric (e.g. instance_info) changes its labels at runtime, e.g. a Valkey upgrade adding new INFO fields
-		if !explicitLabels || slices.Equal(e.metricDescriptionLabels[metricName], labels) {
+		// rebuild when a dynamic-label metric changes its labels at runtime
+		if len(labels) == 0 || slices.Equal(e.metricDescriptionLabels[metricName], labels) {
 			return desc
 		}
 	}


### PR DESCRIPTION
## Problem

After upgrading the monitored Valkey server (e.g. 8.0 → 8.1), the `redis_instance_info` metric disappears from `/metrics` and only comes back after the exporter itself is restarted.

## Root cause
`redis_instance_info` has a **dynamic label set**. In `exporter/info.go` the labels `valkey_version` and  valkey_release_stage` are only added when the server's `INFO` output reports those fields:

```go
if valkeyVersion, ok := keyValues["valkey_version"]; ok { ... }
if valkeyReleaseStage, ok := keyValues["valkey_release_stage"]; ok { ... }
```

`createMetricDescription()` cached the `*prometheus.Desc` by metric name on the first scrape and returned it unchanged forever after, ignoring the `labels` argument on subsequent calls. The description map is built once at construction and lives for the whole process lifetime.

When a Valkey upgrade e.g. adds a new `INFO` field (Valkey 8.1 introduced `valkey_release_stage`), the scrape passes more label values than the cached description has labels. `prometheus.NewConstMetric` then returns a label/value count-mismatch error that is only logged at debug level, and the metric is silently dropped — until the exporter is restarted and rebuilds the description.

## Fix
`createMetricDescription()` now rebuilds the cached description when the explicitly supplied label set differs from the one the cached description was built with (tracked in a new `metricDescriptionLabels` map).

Without this scoping, calling a labeled metric with too few values (e.g. `sentinel_master_ok_sentinels` when sentinel labels are absent) would rebuild it with an empty label set and corrupt the schema.
