### PR TITLE
fix keyspace metrics for Redis and Valkey

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ test:
 	TEST_REDIS_URI="redis://localhost:6379" \
 	TEST_VALKEY7_URI="valkey://localhost:16384" \
 	TEST_VALKEY8_URI="valkey://localhost:16382" \
+	TEST_VALKEY9_URI="valkey://localhost:16382" \
 	TEST_VALKEY8_BUNDLE_URI="valkey://localhost:16389" \
 	TEST_VALKEY8_TLS_URI="valkeys://localhost:16386" \
 	TEST_REDIS7_TLS_URI="rediss://localhost:16387" \

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -538,7 +538,7 @@ func NewRedisExporter(uri string, opts Options) (*Exporter, error) {
 		"db_keys":                                            {txt: "Total number of keys by DB", lbls: []string{"db"}},
 		"db_keys_cached":                                     {txt: "Total number of cached keys by DB", lbls: []string{"db"}},
 		"db_keys_expiring":                                   {txt: "Total number of expiring keys by DB", lbls: []string{"db"}},
-		"db_subkeys_expiring":                                {txt: "Total number of expiring subkeys by DB", lbls: []string{"db"}},
+		"db_keys_with_expiring_items":                        {txt: "Total number of keys with expiring items by DB", lbls: []string{"db"}},
 		"errors_total":                                       {txt: `Total number of errors per error type`, lbls: []string{"err"}},
 		"exporter_last_scrape_error":                         {txt: "The last scrape error status.", lbls: []string{"err"}},
 		"key_group_count":                                    {txt: `Count of keys in key group`, lbls: []string{"db", "key_group"}},

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -538,6 +538,7 @@ func NewRedisExporter(uri string, opts Options) (*Exporter, error) {
 		"db_keys":                                            {txt: "Total number of keys by DB", lbls: []string{"db"}},
 		"db_keys_cached":                                     {txt: "Total number of cached keys by DB", lbls: []string{"db"}},
 		"db_keys_expiring":                                   {txt: "Total number of expiring keys by DB", lbls: []string{"db"}},
+		"db_subkeys_expiring":                                {txt: "Total number of expiring subkeys by DB", lbls: []string{"db"}},
 		"errors_total":                                       {txt: `Total number of errors per error type`, lbls: []string{"err"}},
 		"exporter_last_scrape_error":                         {txt: "The last scrape error status.", lbls: []string{"err"}},
 		"key_group_count":                                    {txt: `Count of keys in key group`, lbls: []string{"db", "key_group"}},

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -986,10 +986,15 @@ db1:keys=18,expires=13,avg_ttl=145372776312,subexpiry=0
 		"test_latency_percentiles_usec":        false,
 		"test_commands_duration_seconds_total": false,
 		"test_commands_total":                  false,
+		"test_db_subkeys_expiring":             false,
 	}
+	foundCachedKeys := false
 
 	for m := range chM {
 		descString := m.Desc().String()
+		if strings.Contains(descString, "test_db_keys_cached") {
+			foundCachedKeys = true
+		}
 		for k := range want {
 			if strings.Contains(descString, k) {
 				want[k] = true
@@ -1001,6 +1006,9 @@ db1:keys=18,expires=13,avg_ttl=145372776312,subexpiry=0
 		if !found {
 			t.Errorf("didn't find metric: %s", k)
 		}
+	}
+	if foundCachedKeys {
+		t.Error("found test_db_keys_cached metric for Redis subexpiry field")
 	}
 }
 

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -986,7 +986,7 @@ db1:keys=18,expires=13,avg_ttl=145372776312,subexpiry=0
 		"test_latency_percentiles_usec":        false,
 		"test_commands_duration_seconds_total": false,
 		"test_commands_total":                  false,
-		"test_db_subkeys_expiring":             false,
+		"test_db_keys_with_expiring_items":     false,
 	}
 	foundCachedKeys := false
 

--- a/exporter/info.go
+++ b/exporter/info.go
@@ -133,19 +133,11 @@ func (e *Exporter) extractInfoMetrics(ch chan<- prometheus.Metric, info string, 
 			continue
 
 		case "Keyspace":
-			if keysTotal, keysEx, avgTTL, keysCached, subkeysExpiring, ok := parseDBKeyspaceString(fieldKey, fieldValue); ok {
+			if metrics, ok := parseDBKeyspaceString(fieldKey, fieldValue); ok {
 				dbName := fieldKey
 
-				e.registerConstMetricGauge(ch, "db_keys", keysTotal, dbName)
-				e.registerConstMetricGauge(ch, "db_keys_expiring", keysEx, dbName)
-				if keysCached > -1 {
-					e.registerConstMetricGauge(ch, "db_keys_cached", keysCached, dbName)
-				}
-				if subkeysExpiring > -1 {
-					e.registerConstMetricGauge(ch, "db_subkeys_expiring", subkeysExpiring, dbName)
-				}
-				if avgTTL > -1 {
-					e.registerConstMetricGauge(ch, "db_avg_ttl_seconds", avgTTL, dbName)
+				for _, metric := range metrics {
+					e.registerConstMetricGauge(ch, metric.name, metric.value, dbName)
 				}
 				handledDBs[dbName] = true
 				continue
@@ -244,59 +236,71 @@ func (e *Exporter) extractClusterInfoMetrics(ch chan<- prometheus.Metric, info s
 	}
 }
 
-func parseDBKeyspaceString(inputKey string, inputVal string) (keysTotal float64, keysExpiringTotal float64, avgTTL float64, keysCachedTotal float64, subkeysExpiringTotal float64, ok bool) {
+type dbKeyspaceMetric struct {
+	name  string
+	value float64
+}
+
+type dbKeyspaceMetricDefinition struct {
+	fields   []string
+	name     string
+	scale    float64
+	required bool
+}
+
+var dbKeyspaceMetricDefinitions = []dbKeyspaceMetricDefinition{
+	{fields: []string{"keys"}, name: "db_keys", scale: 1, required: true},
+	{fields: []string{"expires"}, name: "db_keys_expiring", scale: 1, required: true},
+	{fields: []string{"avg_ttl"}, name: "db_avg_ttl_seconds", scale: 1.0 / 1000},
+	{fields: []string{"cached_keys"}, name: "db_keys_cached", scale: 1},
+	// Redis and Valkey use different names for keys containing expiring sub-items.
+	{fields: []string{"subexpiry", "keys_with_volatile_items"}, name: "db_keys_with_expiring_items", scale: 1},
+}
+
+func parseDBKeyspaceString(inputKey string, inputVal string) (metrics []dbKeyspaceMetric, ok bool) {
 	log.Debugf("parseDBKeyspaceString inputKey: [%s] inputVal: [%s]", inputKey, inputVal)
 
 	if !strings.HasPrefix(inputKey, "db") {
 		log.Debugf("parseDBKeyspaceString inputKey not starting with 'db': [%s]", inputKey)
-		return
+		return nil, false
 	}
 
-	avgTTL = -1
-	keysCachedTotal = -1
-	subkeysExpiringTotal = -1
-	keysFound := false
-	keysExpiringFound := false
-
-	for _, field := range strings.Split(inputVal, ",") {
-		fieldName, _, found := strings.Cut(field, "=")
+	fields := make(map[string]string)
+	for part := range strings.SplitSeq(inputVal, ",") {
+		field, value, found := strings.Cut(part, "=")
 		if !found {
+			log.Debugf("parseDBKeyspaceString invalid field: [%s]", part)
+			return nil, false
+		}
+		fields[field] = value
+	}
+
+	for _, definition := range dbKeyspaceMetricDefinitions {
+		var value string
+		var found bool
+		for _, field := range definition.fields {
+			if value, found = fields[field]; found {
+				break
+			}
+		}
+
+		if !found {
+			if definition.required {
+				log.Debugf("parseDBKeyspaceString missing required field: [%s]", definition.fields[0])
+				return nil, false
+			}
 			continue
 		}
 
-		if fieldName != "keys" && fieldName != "expires" && fieldName != "avg_ttl" && fieldName != "cached_keys" && fieldName != "subexpiry" {
-			continue
-		}
-
-		value, err := extractVal(field)
+		parsed, err := strconv.ParseFloat(value, 64)
 		if err != nil {
-			log.Debugf("parseDBKeyspaceString extractVal(%q) invalid, err: %s", field, err)
-			return
+			log.Debugf("parseDBKeyspaceString invalid field %s=%s, err: %s", definition.fields[0], value, err)
+			return nil, false
 		}
-
-		switch fieldName {
-		case "keys":
-			keysTotal = value
-			keysFound = true
-		case "expires":
-			keysExpiringTotal = value
-			keysExpiringFound = true
-		case "avg_ttl":
-			avgTTL = value / 1000
-		case "cached_keys":
-			keysCachedTotal = value
-		case "subexpiry":
-			subkeysExpiringTotal = value
-		}
+		metrics = append(metrics, dbKeyspaceMetric{name: definition.name, value: parsed * definition.scale})
 	}
 
-	if !keysFound || !keysExpiringFound {
-		log.Debugf("parseDBKeyspaceString missing keys or expires field: [%s]", inputVal)
-		return
-	}
-
-	ok = true
-	return
+	return metrics, true
 }
 
 /*

--- a/exporter/info.go
+++ b/exporter/info.go
@@ -133,13 +133,16 @@ func (e *Exporter) extractInfoMetrics(ch chan<- prometheus.Metric, info string, 
 			continue
 
 		case "Keyspace":
-			if keysTotal, keysEx, avgTTL, keysCached, ok := parseDBKeyspaceString(fieldKey, fieldValue); ok {
+			if keysTotal, keysEx, avgTTL, keysCached, subkeysExpiring, ok := parseDBKeyspaceString(fieldKey, fieldValue); ok {
 				dbName := fieldKey
 
 				e.registerConstMetricGauge(ch, "db_keys", keysTotal, dbName)
 				e.registerConstMetricGauge(ch, "db_keys_expiring", keysEx, dbName)
 				if keysCached > -1 {
 					e.registerConstMetricGauge(ch, "db_keys_cached", keysCached, dbName)
+				}
+				if subkeysExpiring > -1 {
+					e.registerConstMetricGauge(ch, "db_subkeys_expiring", subkeysExpiring, dbName)
 				}
 				if avgTTL > -1 {
 					e.registerConstMetricGauge(ch, "db_avg_ttl_seconds", avgTTL, dbName)
@@ -241,10 +244,7 @@ func (e *Exporter) extractClusterInfoMetrics(ch chan<- prometheus.Metric, info s
 	}
 }
 
-/*
-valid example: db0:keys=1,expires=0,avg_ttl=0,cached_keys=0
-*/
-func parseDBKeyspaceString(inputKey string, inputVal string) (keysTotal float64, keysExpiringTotal float64, avgTTL float64, keysCachedTotal float64, ok bool) {
+func parseDBKeyspaceString(inputKey string, inputVal string) (keysTotal float64, keysExpiringTotal float64, avgTTL float64, keysCachedTotal float64, subkeysExpiringTotal float64, ok bool) {
 	log.Debugf("parseDBKeyspaceString inputKey: [%s] inputVal: [%s]", inputKey, inputVal)
 
 	if !strings.HasPrefix(inputKey, "db") {
@@ -252,37 +252,47 @@ func parseDBKeyspaceString(inputKey string, inputVal string) (keysTotal float64,
 		return
 	}
 
-	split := strings.Split(inputVal, ",")
-	if len(split) < 2 {
-		log.Debugf("parseDBKeyspaceString strings.Split(inputVal) invalid: %#v", split)
-		return
-	}
-
-	var err error
-	if keysTotal, err = extractVal(split[0]); err != nil {
-		log.Debugf("parseDBKeyspaceString extractVal(split[0]) invalid, err: %s", err)
-		return
-	}
-	if keysExpiringTotal, err = extractVal(split[1]); err != nil {
-		log.Debugf("parseDBKeyspaceString extractVal(split[1]) invalid, err: %s", err)
-		return
-	}
-
 	avgTTL = -1
-	if len(split) > 2 {
-		if avgTTL, err = extractVal(split[2]); err != nil {
-			log.Debugf("parseDBKeyspaceString extractVal(split[2]) invalid, err: %s", err)
+	keysCachedTotal = -1
+	subkeysExpiringTotal = -1
+	keysFound := false
+	keysExpiringFound := false
+
+	for _, field := range strings.Split(inputVal, ",") {
+		fieldName, _, found := strings.Cut(field, "=")
+		if !found {
+			continue
+		}
+
+		if fieldName != "keys" && fieldName != "expires" && fieldName != "avg_ttl" && fieldName != "cached_keys" && fieldName != "subexpiry" {
+			continue
+		}
+
+		value, err := extractVal(field)
+		if err != nil {
+			log.Debugf("parseDBKeyspaceString extractVal(%q) invalid, err: %s", field, err)
 			return
 		}
-		avgTTL /= 1000
+
+		switch fieldName {
+		case "keys":
+			keysTotal = value
+			keysFound = true
+		case "expires":
+			keysExpiringTotal = value
+			keysExpiringFound = true
+		case "avg_ttl":
+			avgTTL = value / 1000
+		case "cached_keys":
+			keysCachedTotal = value
+		case "subexpiry":
+			subkeysExpiringTotal = value
+		}
 	}
 
-	keysCachedTotal = -1
-	if len(split) > 3 {
-		if keysCachedTotal, err = extractVal(split[3]); err != nil {
-			log.Debugf("parseDBKeyspaceString extractVal(split[3]) invalid, err: %s", err)
-			return
-		}
+	if !keysFound || !keysExpiringFound {
+		log.Debugf("parseDBKeyspaceString missing keys or expires field: [%s]", inputVal)
+		return
 	}
 
 	ok = true

--- a/exporter/info_test.go
+++ b/exporter/info_test.go
@@ -15,10 +15,10 @@ import (
 
 func TestKeyspaceStringParser(t *testing.T) {
 	tsts := []struct {
-		db                                    string
-		stats                                 string
-		keysTotal, keysEx, keysCached, avgTTL float64
-		ok                                    bool
+		db                                                     string
+		stats                                                  string
+		keysTotal, keysEx, keysCached, subkeysExpiring, avgTTL float64
+		ok                                                     bool
 	}{
 		{db: "xxx", stats: "", ok: false},
 		{db: "xxx", stats: "keys=1,expires=0,avg_ttl=0", ok: false},
@@ -31,32 +31,38 @@ func TestKeyspaceStringParser(t *testing.T) {
 		{db: "db3", stats: "keys=123,expires=0,avg_ttl=zzz", ok: false},
 		{db: "db3", stats: "keys=1,expires=0,avg_ttl=zzz,cached_keys=0", ok: false},
 		{db: "db3", stats: "keys=1,expires=0,avg_ttl=0,cached_keys=zzz", ok: false},
-		{db: "db3", stats: "keys=1,expires=0,avg_ttl=0,cached_keys=0,extra=0", keysTotal: 1, keysEx: 0, avgTTL: 0, keysCached: 0, ok: true},
+		{db: "db3", stats: "keys=1,expires=0,avg_ttl=0,cached_keys=0,extra=0", keysTotal: 1, keysEx: 0, avgTTL: 0, keysCached: 0, subkeysExpiring: -1, ok: true},
 
-		{db: "db0", stats: "keys=1,expires=0,avg_ttl=0", keysTotal: 1, keysEx: 0, avgTTL: 0, keysCached: -1, ok: true},
-		{db: "db0", stats: "keys=1,expires=0,avg_ttl=0,cached_keys=0", keysTotal: 1, keysEx: 0, avgTTL: 0, keysCached: 0, ok: true},
+		{db: "db0", stats: "keys=1,expires=0,avg_ttl=0", keysTotal: 1, keysEx: 0, avgTTL: 0, keysCached: -1, subkeysExpiring: -1, ok: true},
+		{db: "db0", stats: "keys=1,expires=0,avg_ttl=0,cached_keys=0", keysTotal: 1, keysEx: 0, avgTTL: 0, keysCached: 0, subkeysExpiring: -1, ok: true},
 
 		{
 			db: "db0", stats: "keys=25714011,expires=25091314,avg_ttl=685620459,subexpiry=0",
-			keysTotal: 25714011, keysEx: 25091314, keysCached: 0, avgTTL: 685620.459000,
+			keysTotal: 25714011, keysEx: 25091314, keysCached: -1, subkeysExpiring: 0, avgTTL: 685620.459000,
+			ok: true,
+		},
+		{
+			db: "db0", stats: "subexpiry=3,cached_keys=4,expires=2,keys=10,avg_ttl=1000",
+			keysTotal: 10, keysEx: 2, keysCached: 4, subkeysExpiring: 3, avgTTL: 1,
 			ok: true,
 		},
 	}
 
 	for _, tst := range tsts {
-		if kt, kx, ttl, kc, ok := parseDBKeyspaceString(tst.db, tst.stats); true {
+		if kt, kx, ttl, kc, se, ok := parseDBKeyspaceString(tst.db, tst.stats); true {
 
 			if ok != tst.ok {
 				t.Errorf("failed for: db:%s stats:%s", tst.db, tst.stats)
 				continue
 			}
 
-			if ok && (kt != tst.keysTotal || kx != tst.keysEx || kc != tst.keysCached || ttl != tst.avgTTL) {
-				t.Errorf("values not matching, db:%s stats:%s   %f != %f   %f != %f  %f != %f  %f != %f",
+			if ok && (kt != tst.keysTotal || kx != tst.keysEx || kc != tst.keysCached || se != tst.subkeysExpiring || ttl != tst.avgTTL) {
+				t.Errorf("values not matching, db:%s stats:%s   %f != %f   %f != %f  %f != %f  %f != %f  %f != %f",
 					tst.db, tst.stats,
 					kt, tst.keysTotal,
 					kx, tst.keysEx,
 					kc, tst.keysCached,
+					se, tst.subkeysExpiring,
 					ttl, tst.avgTTL)
 			}
 		}

--- a/exporter/info_test.go
+++ b/exporter/info_test.go
@@ -15,57 +15,107 @@ import (
 
 func TestKeyspaceStringParser(t *testing.T) {
 	tsts := []struct {
-		db                                                     string
-		stats                                                  string
-		keysTotal, keysEx, keysCached, subkeysExpiring, avgTTL float64
-		ok                                                     bool
+		name    string
+		db      string
+		stats   string
+		metrics []dbKeyspaceMetric
+		ok      bool
 	}{
-		{db: "xxx", stats: "", ok: false},
-		{db: "xxx", stats: "keys=1,expires=0,avg_ttl=0", ok: false},
-		{db: "db0", stats: "xxx", ok: false},
-		{db: "db1", stats: "keys=abcd,expires=0,avg_ttl=0", ok: false},
-		{db: "db2", stats: "keys=1234=1234,expires=0,avg_ttl=0", ok: false},
-
-		{db: "db3", stats: "keys=abcde,expires=0", ok: false},
-		{db: "db3", stats: "keys=213,expires=xxx", ok: false},
-		{db: "db3", stats: "keys=123,expires=0,avg_ttl=zzz", ok: false},
-		{db: "db3", stats: "keys=1,expires=0,avg_ttl=zzz,cached_keys=0", ok: false},
-		{db: "db3", stats: "keys=1,expires=0,avg_ttl=0,cached_keys=zzz", ok: false},
-		{db: "db3", stats: "keys=1,expires=0,avg_ttl=0,cached_keys=0,extra=0", keysTotal: 1, keysEx: 0, avgTTL: 0, keysCached: 0, subkeysExpiring: -1, ok: true},
-
-		{db: "db0", stats: "keys=1,expires=0,avg_ttl=0", keysTotal: 1, keysEx: 0, avgTTL: 0, keysCached: -1, subkeysExpiring: -1, ok: true},
-		{db: "db0", stats: "keys=1,expires=0,avg_ttl=0,cached_keys=0", keysTotal: 1, keysEx: 0, avgTTL: 0, keysCached: 0, subkeysExpiring: -1, ok: true},
-
 		{
-			db: "db0", stats: "keys=25714011,expires=25091314,avg_ttl=685620459,subexpiry=0",
-			keysTotal: 25714011, keysEx: 25091314, keysCached: -1, subkeysExpiring: 0, avgTTL: 685620.459000,
-			ok: true,
+			name: "wrong key prefix", db: "xxx", stats: "keys=1,expires=0,avg_ttl=0", ok: false,
+		},
+		{name: "malformed", db: "db0", stats: "xxx", ok: false},
+		{name: "invalid keys", db: "db1", stats: "keys=abcd,expires=0,avg_ttl=0", ok: false},
+		{name: "invalid field", db: "db2", stats: "keys=1234=1234,expires=0,avg_ttl=0", ok: false},
+		{name: "missing keys", db: "db3", stats: "expires=0,avg_ttl=0", ok: false},
+		{name: "missing expires", db: "db3", stats: "keys=213,avg_ttl=0", ok: false},
+		{name: "invalid expires", db: "db3", stats: "keys=213,expires=xxx", ok: false},
+		{name: "invalid average ttl", db: "db3", stats: "keys=123,expires=0,avg_ttl=zzz", ok: false},
+		{name: "invalid cached keys", db: "db3", stats: "keys=1,expires=0,avg_ttl=0,cached_keys=zzz", ok: false},
+		{
+			name: "redis without subexpiry", db: "db0", stats: "keys=1,expires=0,avg_ttl=2000",
+			metrics: []dbKeyspaceMetric{{name: "db_keys", value: 1}, {name: "db_keys_expiring", value: 0}, {name: "db_avg_ttl_seconds", value: 2}}, ok: true,
 		},
 		{
-			db: "db0", stats: "subexpiry=3,cached_keys=4,expires=2,keys=10,avg_ttl=1000",
-			keysTotal: 10, keysEx: 2, keysCached: 4, subkeysExpiring: 3, avgTTL: 1,
-			ok: true,
+			name: "redis subexpiry", db: "db0", stats: "subexpiry=7,avg_ttl=685620459,expires=25091314,keys=25714011",
+			metrics: []dbKeyspaceMetric{{name: "db_keys", value: 25714011}, {name: "db_keys_expiring", value: 25091314}, {name: "db_avg_ttl_seconds", value: 685620.459}, {name: "db_keys_with_expiring_items", value: 7}}, ok: true,
+		},
+		{
+			name: "valkey volatile items", db: "db0", stats: "keys=17,expires=5,avg_ttl=2500,keys_with_volatile_items=3",
+			metrics: []dbKeyspaceMetric{{name: "db_keys", value: 17}, {name: "db_keys_expiring", value: 5}, {name: "db_avg_ttl_seconds", value: 2.5}, {name: "db_keys_with_expiring_items", value: 3}}, ok: true,
+		},
+		{
+			name: "cached keys compatibility", db: "db0", stats: "keys=1,expires=0,avg_ttl=0,cached_keys=4,extra=ignored",
+			metrics: []dbKeyspaceMetric{{name: "db_keys", value: 1}, {name: "db_keys_expiring", value: 0}, {name: "db_avg_ttl_seconds", value: 0}, {name: "db_keys_cached", value: 4}}, ok: true,
 		},
 	}
 
 	for _, tst := range tsts {
-		if kt, kx, ttl, kc, se, ok := parseDBKeyspaceString(tst.db, tst.stats); true {
-
+		t.Run(tst.name, func(t *testing.T) {
+			metrics, ok := parseDBKeyspaceString(tst.db, tst.stats)
 			if ok != tst.ok {
-				t.Errorf("failed for: db:%s stats:%s", tst.db, tst.stats)
-				continue
+				t.Fatalf("parseDBKeyspaceString(%q, %q) ok = %t, want %t", tst.db, tst.stats, ok, tst.ok)
 			}
 
-			if ok && (kt != tst.keysTotal || kx != tst.keysEx || kc != tst.keysCached || se != tst.subkeysExpiring || ttl != tst.avgTTL) {
-				t.Errorf("values not matching, db:%s stats:%s   %f != %f   %f != %f  %f != %f  %f != %f  %f != %f",
-					tst.db, tst.stats,
-					kt, tst.keysTotal,
-					kx, tst.keysEx,
-					kc, tst.keysCached,
-					se, tst.subkeysExpiring,
-					ttl, tst.avgTTL)
+			if ok && !reflect.DeepEqual(metrics, tst.metrics) {
+				t.Errorf("parseDBKeyspaceString(%q, %q) metrics = %#v, want %#v", tst.db, tst.stats, metrics, tst.metrics)
 			}
-		}
+		})
+	}
+}
+
+func TestExtractInfoKeyspaceMetrics(t *testing.T) {
+	tests := []struct {
+		name     string
+		keyspace string
+		want     []string
+		dontWant []string
+	}{
+		{
+			name: "redis", keyspace: "db0:keys=5,expires=3,avg_ttl=1000,subexpiry=2",
+			want:     []string{"test_db_keys", "test_db_keys_expiring", "test_db_avg_ttl_seconds", "test_db_keys_with_expiring_items"},
+			dontWant: []string{"test_db_keys_cached"},
+		},
+		{
+			name: "valkey", keyspace: "db0:keys=5,expires=3,avg_ttl=1000,keys_with_volatile_items=2",
+			want:     []string{"test_db_keys", "test_db_keys_expiring", "test_db_avg_ttl_seconds", "test_db_keys_with_expiring_items"},
+			dontWant: []string{"test_db_keys_cached"},
+		},
+		{
+			name: "cached keys compatibility", keyspace: "db0:keys=5,expires=3,avg_ttl=1000,cached_keys=2",
+			want:     []string{"test_db_keys", "test_db_keys_expiring", "test_db_avg_ttl_seconds", "test_db_keys_cached"},
+			dontWant: []string{"test_db_keys_with_expiring_items"},
+		},
+	}
+
+	for _, tst := range tests {
+		t.Run(tst.name, func(t *testing.T) {
+			e, err := NewRedisExporter("unix:///tmp/doesnt.matter", Options{Namespace: "test"})
+			if err != nil {
+				t.Fatalf("NewRedisExporter() error = %v", err)
+			}
+
+			ch := make(chan prometheus.Metric)
+			go func() {
+				e.extractInfoMetrics(ch, "# Keyspace\n"+tst.keyspace+"\n", 0)
+				close(ch)
+			}()
+
+			descriptions := ""
+			for metric := range ch {
+				descriptions += metric.Desc().String() + "\n"
+			}
+			for _, metric := range tst.want {
+				if !strings.Contains(descriptions, `fqName: "`+metric+`"`) {
+					t.Errorf("missing metric %s", metric)
+				}
+			}
+			for _, metric := range tst.dontWant {
+				if strings.Contains(descriptions, `fqName: "`+metric+`"`) {
+					t.Errorf("unexpected metric %s", metric)
+				}
+			}
+		})
 	}
 }
 

--- a/exporter/info_test.go
+++ b/exporter/info_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gomodule/redigo/redis"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 )
@@ -114,6 +115,74 @@ func TestExtractInfoKeyspaceMetrics(t *testing.T) {
 				if strings.Contains(descriptions, `fqName: "`+metric+`"`) {
 					t.Errorf("unexpected metric %s", metric)
 				}
+			}
+		})
+	}
+}
+
+func TestLiveKeyspaceExpiringItemsMetric(t *testing.T) {
+	tests := []struct {
+		name        string
+		env         string
+		sourceField string
+	}{
+		{name: "redis", env: "TEST_REDIS88_URI", sourceField: "subexpiry"},
+		{name: "valkey", env: "TEST_VALKEY9_URI", sourceField: "keys_with_volatile_items"},
+	}
+
+	for _, tst := range tests {
+		t.Run(tst.name, func(t *testing.T) {
+			addr := os.Getenv(tst.env)
+			if addr == "" {
+				t.Skipf("%s not set - skipping", tst.env)
+			}
+
+			e, err := NewRedisExporter(addr, Options{Namespace: "test"})
+			if err != nil {
+				t.Fatalf("NewRedisExporter() error = %v", err)
+			}
+			c, err := e.connectToRedis()
+			if err != nil {
+				t.Fatalf("connectToRedis() error = %v", err)
+			}
+			defer c.Close()
+
+			const db = "15"
+			if _, err := c.Do("SELECT", db); err != nil {
+				t.Fatalf("SELECT %s error = %v", db, err)
+			}
+			if _, err := c.Do("FLUSHDB"); err != nil {
+				t.Fatalf("FLUSHDB error = %v", err)
+			}
+			defer c.Do("FLUSHDB")
+
+			if _, err := c.Do("HSET", "expiring-items-test", "field", "value"); err != nil {
+				t.Fatalf("HSET error = %v", err)
+			}
+			result, err := redis.Ints(c.Do("HEXPIRE", "expiring-items-test", 600, "FIELDS", 1, "field"))
+			if err != nil {
+				t.Fatalf("HEXPIRE error = %v", err)
+			}
+			if !reflect.DeepEqual(result, []int{1}) {
+				t.Fatalf("HEXPIRE result = %v, want [1]", result)
+			}
+
+			info, err := redis.String(c.Do("INFO", "KEYSPACE"))
+			if err != nil {
+				t.Fatalf("INFO KEYSPACE error = %v", err)
+			}
+			if !strings.Contains(info, tst.sourceField+"=1") {
+				t.Fatalf("INFO KEYSPACE missing %s=1:\n%s", tst.sourceField, info)
+			}
+
+			ts := httptest.NewServer(e)
+			defer ts.Close()
+			body := downloadURL(t, ts.URL+"/metrics")
+			if want := `test_db_keys_with_expiring_items{db="db15"} 1`; !strings.Contains(body, want) {
+				t.Errorf("missing metric %q:\n%s", want, body)
+			}
+			if strings.Contains(body, `test_db_keys_cached{db="db15"}`) {
+				t.Errorf("unexpected cached-keys metric for db15:\n%s", body)
 			}
 		})
 	}


### PR DESCRIPTION
Parse INFO keyspace fields by name instead of position. Redis `subexpiry` and Valkey `keys_with_volatile_items` now map to `redis_db_keys_with_expiring_items`, while `redis_db_keys_cached` is emitted only for an actual `cached_keys` field. Includes parser and emitted-metric unit coverage plus live Redis 8.8 and Valkey 9 tests that create hash-field expirations and scrape the exporter.