### PR TITLE
test: run Valkey coverage against Valkey 9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,9 @@ test-certs:
 .PHONY: test
 test:
 	TEST_REDIS_URI="redis://localhost:6379" \
-	TEST_VALKEY7_URI="valkey://localhost:16384" \
-	TEST_VALKEY8_URI="valkey://localhost:16382" \
 	TEST_VALKEY9_URI="valkey://localhost:16382" \
-	TEST_VALKEY8_BUNDLE_URI="valkey://localhost:16389" \
-	TEST_VALKEY8_TLS_URI="valkeys://localhost:16386" \
+	TEST_VALKEY9_BUNDLE_URI="valkey://localhost:16389" \
+	TEST_VALKEY9_TLS_URI="valkeys://localhost:16386" \
 	TEST_REDIS7_TLS_URI="rediss://localhost:16387" \
 	TEST_REDIS8_URI="redis://localhost:16388" \
 	TEST_REDIS88_URI="redis://localhost:16488" \
@@ -50,9 +48,9 @@ test:
 	TEST_KEYDB02_URI="redis://localhost:16402" \
 	TEST_PWD_REDIS_URI="redis://:redis-password@localhost:16380" \
 	TEST_USER_PWD_REDIS_URI="redis://exporter:exporter-password@localhost:16390" \
-	TEST_REDIS_CLUSTER_MASTER_URI="redis://localhost:17000" \
+	TEST_VALKEY_CLUSTER_MASTER_URI="redis://localhost:17000" \
 	TEST_REDIS88_CLUSTER_MASTER_URI="redis://localhost:47000" \
-	TEST_REDIS_CLUSTER_SLAVE_URI="redis://localhost:17005" \
+	TEST_VALKEY_CLUSTER_SLAVE_URI="redis://localhost:17005" \
 	TEST_VALKEY_CLUSTER_PASSWORD_URI="redis://localhost:17006" \
 	TEST_TILE38_URI="redis://localhost:19851" \
 	TEST_VALKEY_SENTINEL_URI="redis://localhost:26379" \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,17 +20,11 @@ services:
     ports:
       - "16386:6379"
 
-  valkey8-bundle:
-    image: valkey/valkey-bundle:8
+  valkey9-bundle:
+    image: valkey/valkey-bundle:9
     command: "valkey-server --enable-debug-command yes --protected-mode no"
     ports:
       - "16389:6379"
-
-  valkey8:
-    image: valkey/valkey:8
-    command: "valkey-server --enable-debug-command yes --protected-mode no"
-    ports:
-      - "16384:6379"
 
   redis8:
     image: redis:8.6.3
@@ -102,8 +96,8 @@ services:
     ports:
       - "16402:6379"
 
-  valkey-cluster:
-    image: oliver006/valkey-cluster:8.1.3
+  valkey9-cluster:
+    image: oliver006/valkey-cluster:9.0.1
     environment:
       - IP=0.0.0.0
     ports:
@@ -120,8 +114,8 @@ services:
     ports:
       - 47000-47005:47000-47005
 
-  valkey-cluster-password:
-    image: oliver006/valkey-cluster:8.1.3
+  valkey9-cluster-password:
+    image: oliver006/valkey-cluster:9.0.1
     environment:
       - IP=0.0.0.0
       - INITIAL_PORT=7006
@@ -133,12 +127,12 @@ services:
   valkey-sentinel:
     image: valkey/valkey:9
     depends_on:
-      - valkey8
+      - valkey9
     ports:
       - "26379:26379"
     command: >
       sh -c 'echo "sentinel resolve-hostnames yes" > /etc/sentinel.conf &&
-            echo "sentinel monitor mymaster valkey8 6379 1" >> /etc/sentinel.conf &&
+            echo "sentinel monitor mymaster valkey9 6379 1" >> /etc/sentinel.conf &&
             echo "sentinel down-after-milliseconds mymaster 1000" >> /etc/sentinel.conf &&
             echo "sentinel failover-timeout mymaster 5000" >> /etc/sentinel.conf &&
             echo "sentinel parallel-syncs mymaster 1" >> /etc/sentinel.conf &&

--- a/exporter/commandlog_test.go
+++ b/exporter/commandlog_test.go
@@ -19,9 +19,9 @@ const (
 )
 
 func TestCommandLog(t *testing.T) {
-	addr := os.Getenv("TEST_VALKEY8_URI")
+	addr := os.Getenv("TEST_VALKEY9_URI")
 	if addr == "" {
-		t.Skipf("TEST_VALKEY8_URI not set - skipping")
+		t.Skipf("TEST_VALKEY9_URI not set - skipping")
 	}
 
 	e := getTestExporterWithAddr(addr)

--- a/exporter/http_test.go
+++ b/exporter/http_test.go
@@ -207,10 +207,11 @@ func TestSimultaneousMetricsHttpRequests(t *testing.T) {
 		os.Getenv("TEST_KEYDB02_URI") == "" ||
 		os.Getenv("TEST_REDIS5_URI") == "" ||
 		os.Getenv("TEST_REDIS6_URI") == "" ||
-		os.Getenv("TEST_REDIS_CLUSTER_MASTER_URI") == "" ||
-		os.Getenv("TEST_REDIS_CLUSTER_SLAVE_URI") == "" ||
+		os.Getenv("TEST_VALKEY_CLUSTER_MASTER_URI") == "" ||
+		os.Getenv("TEST_VALKEY_CLUSTER_SLAVE_URI") == "" ||
 		os.Getenv("TEST_TILE38_URI") == "" ||
-		os.Getenv("TEST_VALKEY8_BUNDLE_URI") == "" {
+		os.Getenv("TEST_VALKEY9_URI") == "" ||
+		os.Getenv("TEST_VALKEY9_BUNDLE_URI") == "" {
 		t.Skipf("Skipping TestSimultaneousMetricsHttpRequests, missing env vars")
 	}
 
@@ -226,19 +227,18 @@ func TestSimultaneousMetricsHttpRequests(t *testing.T) {
 
 		os.Getenv("TEST_REDIS7_URI"),
 
-		os.Getenv("TEST_VALKEY7_URI"),
-		os.Getenv("TEST_VALKEY8_URI"),
+		os.Getenv("TEST_VALKEY9_URI"),
 
 		os.Getenv("TEST_KEYDB01_URI"),
 		os.Getenv("TEST_KEYDB02_URI"),
 
 		os.Getenv("TEST_REDIS5_URI"),
 		os.Getenv("TEST_REDIS6_URI"),
-		os.Getenv("TEST_VALKEY8_BUNDLE_URI"),
+		os.Getenv("TEST_VALKEY9_BUNDLE_URI"),
 
-		// tile38 & Cluster need to be last in this list, so we can identify them when selected, down in line 229
-		os.Getenv("TEST_REDIS_CLUSTER_MASTER_URI"),
-		os.Getenv("TEST_REDIS_CLUSTER_SLAVE_URI"),
+		// Tile38 and cluster targets need to be last so they can be identified below.
+		os.Getenv("TEST_VALKEY_CLUSTER_MASTER_URI"),
+		os.Getenv("TEST_VALKEY_CLUSTER_SLAVE_URI"),
 		os.Getenv("TEST_TILE38_URI"),
 	}
 
@@ -318,10 +318,10 @@ func TestHttpHandlers(t *testing.T) {
 }
 
 func TestHttpDiscoverClusterNodesHandlers(t *testing.T) {
-	clusterAddr := os.Getenv("TEST_REDIS_CLUSTER_MASTER_URI")
+	clusterAddr := os.Getenv("TEST_VALKEY_CLUSTER_MASTER_URI")
 	nonClusterAddr := os.Getenv("TEST_REDIS_URI")
 	if clusterAddr == "" || nonClusterAddr == "" {
-		t.Skipf("TEST_REDIS_CLUSTER_MASTER_URI or TEST_REDIS_URI not set - skipping")
+		t.Skipf("TEST_VALKEY_CLUSTER_MASTER_URI or TEST_REDIS_URI not set - skipping")
 	}
 
 	tests := []struct {

--- a/exporter/info_test.go
+++ b/exporter/info_test.go
@@ -334,11 +334,11 @@ func TestInclMetricsForEmptyDatabases(t *testing.T) {
 }
 
 func TestClusterMaster(t *testing.T) {
-	if os.Getenv("TEST_REDIS_CLUSTER_MASTER_URI") == "" {
-		t.Skipf("TEST_REDIS_CLUSTER_MASTER_URI not set - skipping")
+	if os.Getenv("TEST_VALKEY_CLUSTER_MASTER_URI") == "" {
+		t.Skipf("TEST_VALKEY_CLUSTER_MASTER_URI not set - skipping")
 	}
 
-	addr := os.Getenv("TEST_REDIS_CLUSTER_MASTER_URI")
+	addr := os.Getenv("TEST_VALKEY_CLUSTER_MASTER_URI")
 	e, _ := NewRedisExporter(addr, Options{Namespace: "test"})
 	ts := httptest.NewServer(e)
 	defer ts.Close()
@@ -356,10 +356,10 @@ func TestClusterMaster(t *testing.T) {
 }
 
 func TestClusterSkipCheckKeysIfMaster(t *testing.T) {
-	uriMaster := os.Getenv("TEST_REDIS_CLUSTER_MASTER_URI")
-	uriSlave := os.Getenv("TEST_REDIS_CLUSTER_SLAVE_URI")
+	uriMaster := os.Getenv("TEST_VALKEY_CLUSTER_MASTER_URI")
+	uriSlave := os.Getenv("TEST_VALKEY_CLUSTER_SLAVE_URI")
 	if uriMaster == "" || uriSlave == "" {
-		t.Skipf("TEST_REDIS_CLUSTER_MASTER_URI or slave not set - skipping")
+		t.Skipf("TEST_VALKEY_CLUSTER_MASTER_URI or slave not set - skipping")
 	}
 
 	setupTestKeysCluster(t, uriMaster)
@@ -403,11 +403,11 @@ func TestClusterSkipCheckKeysIfMaster(t *testing.T) {
 }
 
 func TestClusterSlave(t *testing.T) {
-	if os.Getenv("TEST_REDIS_CLUSTER_SLAVE_URI") == "" {
-		t.Skipf("TEST_REDIS_CLUSTER_SLAVE_URI not set - skipping")
+	if os.Getenv("TEST_VALKEY_CLUSTER_SLAVE_URI") == "" {
+		t.Skipf("TEST_VALKEY_CLUSTER_SLAVE_URI not set - skipping")
 	}
 
-	addr := os.Getenv("TEST_REDIS_CLUSTER_SLAVE_URI")
+	addr := os.Getenv("TEST_VALKEY_CLUSTER_SLAVE_URI")
 	e, _ := NewRedisExporter(addr, Options{Namespace: "test"})
 	ts := httptest.NewServer(e)
 	defer ts.Close()

--- a/exporter/keys_test.go
+++ b/exporter/keys_test.go
@@ -78,9 +78,9 @@ func TestKeyValuesAsLabel(t *testing.T) {
 }
 
 func TestClusterKeyValuesAndSizes(t *testing.T) {
-	clusterUri := os.Getenv("TEST_REDIS_CLUSTER_MASTER_URI")
+	clusterUri := os.Getenv("TEST_VALKEY_CLUSTER_MASTER_URI")
 	if clusterUri == "" {
-		t.Skipf("Skipping TestClusterKeyValuesAndSizes, don't have env var TEST_REDIS_CLUSTER_MASTER_URI")
+		t.Skipf("Skipping TestClusterKeyValuesAndSizes, don't have env var TEST_VALKEY_CLUSTER_MASTER_URI")
 	}
 	setupTestKeysCluster(t, clusterUri)
 	defer deleteTestKeysCluster(t, clusterUri)
@@ -616,9 +616,9 @@ func TestCheckKeysMultipleDBs(t *testing.T) {
 }
 
 func TestClusterGetKeyInfo(t *testing.T) {
-	clusterUri := os.Getenv("TEST_REDIS_CLUSTER_MASTER_URI")
+	clusterUri := os.Getenv("TEST_VALKEY_CLUSTER_MASTER_URI")
 	if clusterUri == "" {
-		t.Skipf("Skipping TestClusterKeyValuesAndSizes, don't have env var TEST_REDIS_CLUSTER_MASTER_URI")
+		t.Skipf("Skipping TestClusterKeyValuesAndSizes, don't have env var TEST_VALKEY_CLUSTER_MASTER_URI")
 	}
 
 	e, _ := NewRedisExporter(

--- a/exporter/modules_test.go
+++ b/exporter/modules_test.go
@@ -62,11 +62,11 @@ func TestModulesv80(t *testing.T) {
 }
 
 func TestModulesValkey(t *testing.T) {
-	if os.Getenv("TEST_VALKEY8_BUNDLE_URI") == "" {
-		t.Skipf("TEST_VALKEY8_BUNDLE_URI not set - skipping")
+	if os.Getenv("TEST_VALKEY9_BUNDLE_URI") == "" {
+		t.Skipf("TEST_VALKEY9_BUNDLE_URI not set - skipping")
 	}
 
-	testModuleMetrics(t, os.Getenv("TEST_VALKEY8_BUNDLE_URI"), []string{
+	testModuleMetrics(t, os.Getenv("TEST_VALKEY9_BUNDLE_URI"), []string{
 		"module_info",
 		"search_number_of_indexes",
 		"bf_bloom_total_memory_bytes",

--- a/exporter/nodes_test.go
+++ b/exporter/nodes_test.go
@@ -7,9 +7,9 @@ import (
 )
 
 func TestNodesGetClusterNodes(t *testing.T) {
-	host := os.Getenv("TEST_REDIS_CLUSTER_MASTER_URI")
+	host := os.Getenv("TEST_VALKEY_CLUSTER_MASTER_URI")
 	if host == "" {
-		t.Skipf("TEST_REDIS_CLUSTER_MASTER_URI not set - skipping")
+		t.Skipf("TEST_VALKEY_CLUSTER_MASTER_URI not set - skipping")
 	}
 
 	e, _ := NewRedisExporter(host, Options{})

--- a/exporter/redis_test.go
+++ b/exporter/redis_test.go
@@ -28,7 +28,7 @@ func TestHostVariations(t *testing.T) {
 }
 
 func TestValkeyScheme(t *testing.T) {
-	host := os.Getenv("TEST_VALKEY8_URI")
+	host := os.Getenv("TEST_VALKEY9_URI")
 
 	e, _ := NewRedisExporter(host, Options{SkipTLSVerification: true})
 	c, err := e.connectToRedis()
@@ -122,7 +122,7 @@ func TestConnectToClusterUsingPasswordFile(t *testing.T) {
 		t.Skipf("TEST_VALKEY_CLUSTER_PASSWORD_URI is not set")
 	}
 	passMap := map[string]string{clusterUri: "redis-password"}
-	wrongPassMap := map[string]string{"redis://redis-cluster-password-wrong:7006": "redis-password"}
+	wrongPassMap := map[string]string{"redis://valkey-cluster-password-wrong:7006": "redis-password"}
 
 	tsts := []struct {
 		name         string

--- a/exporter/search_indexes_test.go
+++ b/exporter/search_indexes_test.go
@@ -27,16 +27,16 @@ func setupSearchIndex(t *testing.T, addr string) error {
 }
 
 func TestExtractSearchIndexesMetrics(t *testing.T) {
-	test_redis8_uri := os.Getenv("TEST_REDIS8_URI")
-	test_valkey8_bundle_uri := os.Getenv("TEST_VALKEY8_BUNDLE_URI")
-	if test_redis8_uri == "" || test_valkey8_bundle_uri == "" {
-		t.Skipf("TEST_REDIS8_URI or TEST_VALKEY8_BUNDLE_URI aren't set - skipping")
+	testRedis8URI := os.Getenv("TEST_REDIS8_URI")
+	testValkey9BundleURI := os.Getenv("TEST_VALKEY9_BUNDLE_URI")
+	if testRedis8URI == "" || testValkey9BundleURI == "" {
+		t.Skipf("TEST_REDIS8_URI or TEST_VALKEY9_BUNDLE_URI aren't set - skipping")
 	}
-	if err := setupSearchIndex(t, test_redis8_uri); err != nil {
-		t.Fatalf("couldn't create search index in TEST_REDIS8_URI (%s), err: %s ", test_redis8_uri, err)
+	if err := setupSearchIndex(t, testRedis8URI); err != nil {
+		t.Fatalf("couldn't create search index in TEST_REDIS8_URI (%s), err: %s ", testRedis8URI, err)
 	}
-	if err := setupSearchIndex(t, test_valkey8_bundle_uri); err != nil {
-		t.Fatalf("couldn't create search index in TEST_VALKEY8_BUNDLE_URI (%s), err: %s ", test_valkey8_bundle_uri, err)
+	if err := setupSearchIndex(t, testValkey9BundleURI); err != nil {
+		t.Fatalf("couldn't create search index in TEST_VALKEY9_BUNDLE_URI (%s), err: %s ", testValkey9BundleURI, err)
 	}
 
 	tsts := []struct {
@@ -44,10 +44,10 @@ func TestExtractSearchIndexesMetrics(t *testing.T) {
 		inclSearchIndexesMetrics bool
 		wantSearchIndexesMetrics bool
 	}{
-		{addr: test_redis8_uri, inclSearchIndexesMetrics: true, wantSearchIndexesMetrics: true},
-		{addr: test_redis8_uri, inclSearchIndexesMetrics: false, wantSearchIndexesMetrics: false},
-		{addr: test_valkey8_bundle_uri, inclSearchIndexesMetrics: true, wantSearchIndexesMetrics: true},
-		{addr: test_valkey8_bundle_uri, inclSearchIndexesMetrics: false, wantSearchIndexesMetrics: false},
+		{addr: testRedis8URI, inclSearchIndexesMetrics: true, wantSearchIndexesMetrics: true},
+		{addr: testRedis8URI, inclSearchIndexesMetrics: false, wantSearchIndexesMetrics: false},
+		{addr: testValkey9BundleURI, inclSearchIndexesMetrics: true, wantSearchIndexesMetrics: true},
+		{addr: testValkey9BundleURI, inclSearchIndexesMetrics: false, wantSearchIndexesMetrics: false},
 	}
 
 	for _, tst := range tsts {

--- a/exporter/streams_test.go
+++ b/exporter/streams_test.go
@@ -102,12 +102,12 @@ func TestStreamsGetStreamInfo(t *testing.T) {
 	}
 }
 
-func TestStreamsGetStreamInfoUsingValKey7(t *testing.T) {
-	if os.Getenv("TEST_VALKEY7_URI") == "" {
-		t.Skipf("TEST_VALKEY7_URI not set - skipping")
+func TestStreamsGetStreamInfoUsingValkey9(t *testing.T) {
+	if os.Getenv("TEST_VALKEY9_URI") == "" {
+		t.Skipf("TEST_VALKEY9_URI not set - skipping")
 	}
 
-	addr := strings.Replace(os.Getenv("TEST_VALKEY7_URI"), "valkey://", "redis://", 1)
+	addr := strings.Replace(os.Getenv("TEST_VALKEY9_URI"), "valkey://", "redis://", 1)
 	c, err := redis.DialURL(addr)
 	if err != nil {
 		t.Fatalf("Couldn't connect to %#v: %#v", addr, err)
@@ -282,11 +282,11 @@ func TestStreamsScanStreamGroups123(t *testing.T) {
 	}
 }
 
-func TestStreamsScanStreamGroupsUsingValKey7(t *testing.T) {
-	if os.Getenv("TEST_VALKEY7_URI") == "" {
-		t.Skipf("TEST_VALKEY7_URI not set - skipping")
+func TestStreamsScanStreamGroupsUsingValkey9(t *testing.T) {
+	if os.Getenv("TEST_VALKEY9_URI") == "" {
+		t.Skipf("TEST_VALKEY9_URI not set - skipping")
 	}
-	addr := strings.Replace(os.Getenv("TEST_VALKEY7_URI"), "valkey://", "redis://", 1)
+	addr := strings.Replace(os.Getenv("TEST_VALKEY9_URI"), "valkey://", "redis://", 1)
 	db := dbNumStr
 
 	c, err := redis.DialURL(addr)
@@ -625,11 +625,11 @@ func TestStreamsExtractStreamMetricsExcludeConsumer(t *testing.T) {
 }
 
 func TestClusterStreamMetricsExtraction(t *testing.T) {
-	if os.Getenv("TEST_REDIS_CLUSTER_MASTER_URI") == "" {
-		t.Skipf("TEST_REDIS_CLUSTER_MASTER_URI not set - skipping cluster stream test")
+	if os.Getenv("TEST_VALKEY_CLUSTER_MASTER_URI") == "" {
+		t.Skipf("TEST_VALKEY_CLUSTER_MASTER_URI not set - skipping cluster stream test")
 	}
 
-	clusterURI := os.Getenv("TEST_REDIS_CLUSTER_MASTER_URI")
+	clusterURI := os.Getenv("TEST_VALKEY_CLUSTER_MASTER_URI")
 
 	// Test streams to create
 	testStreams := []string{"audit_stream", "sa_audit_stream", "test_stream_cluster"}

--- a/exporter/tls_test.go
+++ b/exporter/tls_test.go
@@ -409,10 +409,10 @@ func waitForCapturedSNI(t *testing.T, sniCh <-chan string) string {
 	}
 }
 
-func TestValkeyTLSScheme(t *testing.T) {
+func TestRedisAndValkeyTLSSchemes(t *testing.T) {
 	for _, host := range []string{
 		os.Getenv("TEST_REDIS7_TLS_URI"),
-		os.Getenv("TEST_VALKEY8_TLS_URI"),
+		os.Getenv("TEST_VALKEY9_TLS_URI"),
 	} {
 		t.Run(host, func(t *testing.T) {
 			if host == "" {


### PR DESCRIPTION
Update all generic Valkey test targets to Valkey 9. Removes the stale Valkey 7/8 aliases, upgrades standalone, TLS, bundle, cluster, password-cluster, and Sentinel fixtures, and renames environment variables to match the actual servers. The custom cluster uses its available Valkey 9.0.1 image.