### PR TITLE
more slowlogs, stream, clients metrics

### DIFF
--- a/exporter/clients.go
+++ b/exporter/clients.go
@@ -34,6 +34,12 @@ type ClientInfo struct {
 	Oll,
 	OMem,
 	TotMem int64
+	ReadEvents,
+	PipelineLengthSum,
+	PipelineLengthCount uint64
+	readEventsAvailable,
+	pipelineLengthSumAvailable,
+	pipelineLengthCountAvailable bool
 }
 
 /*
@@ -101,6 +107,21 @@ func parseClientListString(clientInfo string) (*ClientInfo, bool) {
 			connectedClient.OMem, _ = strconv.ParseInt(vPart[1], 10, 64)
 		case "tot-mem":
 			connectedClient.TotMem, _ = strconv.ParseInt(vPart[1], 10, 64)
+		case "read-events":
+			if value, err := strconv.ParseUint(vPart[1], 10, 64); err == nil {
+				connectedClient.ReadEvents = value
+				connectedClient.readEventsAvailable = true
+			}
+		case "avg-pipeline-len-sum":
+			if value, err := strconv.ParseUint(vPart[1], 10, 64); err == nil {
+				connectedClient.PipelineLengthSum = value
+				connectedClient.pipelineLengthSumAvailable = true
+			}
+		case "avg-pipeline-len-cnt":
+			if value, err := strconv.ParseUint(vPart[1], 10, 64); err == nil {
+				connectedClient.PipelineLengthCount = value
+				connectedClient.pipelineLengthCountAvailable = true
+			}
 		case "addr":
 			hostPortString := strings.Split(vPart[1], ":")
 			if len(hostPortString) < 2 {
@@ -181,6 +202,9 @@ func (e *Exporter) parseConnectedClientMetrics(input string, ch chan<- prometheu
 			"connected_client_query_buffer_free_space_bytes",
 			"connected_client_output_buffer_length_bytes",
 			"connected_client_output_list_length",
+			"connected_client_read_events_total",
+			"connected_client_pipeline_commands_total",
+			"connected_client_pipeline_batches_total",
 		} {
 			e.createMetricDescription(metricName, clientBaseLabels)
 		}
@@ -234,6 +258,25 @@ func (e *Exporter) parseConnectedClientMetrics(input string, ch chan<- prometheu
 			ch, "connected_client_output_list_length", float64(info.Oll),
 			clientBaseLabelsValues...,
 		)
+
+		if info.readEventsAvailable {
+			e.registerConstMetric(
+				ch, "connected_client_read_events_total", float64(info.ReadEvents), prometheus.CounterValue,
+				clientBaseLabelsValues...,
+			)
+		}
+		if info.pipelineLengthSumAvailable {
+			e.registerConstMetric(
+				ch, "connected_client_pipeline_commands_total", float64(info.PipelineLengthSum), prometheus.CounterValue,
+				clientBaseLabelsValues...,
+			)
+		}
+		if info.pipelineLengthCountAvailable {
+			e.registerConstMetric(
+				ch, "connected_client_pipeline_batches_total", float64(info.PipelineLengthCount), prometheus.CounterValue,
+				clientBaseLabelsValues...,
+			)
+		}
 
 		if info.Ssub != -1 {
 			e.createMetricDescription("connected_client_shard_channel_subscriptions_count", clientBaseLabels)

--- a/exporter/clients_test.go
+++ b/exporter/clients_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 )
 
 func TestDurationFieldToTimestamp(t *testing.T) {
@@ -76,6 +77,14 @@ func TestParseClientListString(t *testing.T) {
 			expectedOk:   true,
 			expectedInfo: ClientInfo{Id: "40253233", CreatedAt: convertDurationToTimestampInt64("782"), IdleSince: convertDurationToTimestampInt64("0"), Flags: "N", Db: "0", Sub: 896, Psub: 18, Ssub: 17, Watch: 3, Qbuf: 26, QbufFree: 32742, Oll: 555, OMem: 0, TotMem: 61466, Host: "fd40:1481:21:dbe0:7021:300:a03:1a06", Port: "44426", User: "default"},
 		}, {
+			in:         "id=15 addr=127.0.0.1:64960 name=worker read-events=42 avg-pipeline-len-sum=12 avg-pipeline-len-cnt=4",
+			expectedOk: true,
+			expectedInfo: ClientInfo{
+				Id: "15", Name: "worker", Ssub: -1, Watch: -1, Host: "127.0.0.1", Port: "64960",
+				ReadEvents: 42, PipelineLengthSum: 12, PipelineLengthCount: 4,
+				readEventsAvailable: true, pipelineLengthSumAvailable: true, pipelineLengthCountAvailable: true,
+			},
+		}, {
 			in:         "id=14 addr=127.0.0.1:64958 fd=9 name=foo age=ABCDE idle=0 flags=N db=1 sub=0 psub=0 multi=-1 qbuf=26 qbuf-free=32742 obl=0 oll=0 omem=0 tot-mem=0 events=r cmd=client",
 			expectedOk: false,
 		}, {
@@ -138,6 +147,47 @@ func TestParseClientListString(t *testing.T) {
 
 		if *info != tst.expectedInfo {
 			t.Errorf("TestParseClientListString( %s ) error. Given: %#v Wanted: %#v", tst.in, info, tst.expectedInfo)
+		}
+	}
+}
+
+func TestRedisEightEightClientProcessingMetrics(t *testing.T) {
+	e := getTestExporterWithOptions(t, Options{Namespace: "test"})
+	input := "id=15 addr=127.0.0.1:64960 name=worker read-events=42 avg-pipeline-len-sum=12 avg-pipeline-len-cnt=4\n"
+	want := map[string]float64{
+		"connected_client_read_events_total":       42,
+		"connected_client_pipeline_commands_total": 12,
+		"connected_client_pipeline_batches_total":  4,
+	}
+	found := map[string]bool{}
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		e.parseConnectedClientMetrics(input, ch)
+		close(ch)
+	}()
+	for metric := range ch {
+		for name, expected := range want {
+			if !strings.Contains(metric.Desc().String(), `fqName: "test_`+name+`"`) {
+				continue
+			}
+			var got dto.Metric
+			if err := metric.Write(&got); err != nil {
+				t.Fatalf("metric.Write(%s) err: %s", name, err)
+			}
+			if got.Counter == nil {
+				t.Errorf("%s is not a counter", name)
+				continue
+			}
+			if got.Counter.GetValue() != expected {
+				t.Errorf("%s value = %v, want %v", name, got.Counter.GetValue(), expected)
+			}
+			found[name] = true
+		}
+	}
+	for name := range want {
+		if !found[name] {
+			t.Errorf("metric %s was not emitted", name)
 		}
 	}
 }

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -171,6 +171,7 @@ func NewRedisExporter(uri string, opts Options) (*Exporter, error) {
 
 			// # Clients
 			"connected_clients":            "connected_clients",
+			"active_clients":               "active_clients", // Added in Redis 8.8
 			"blocked_clients":              "blocked_clients",
 			"maxclients":                   "max_clients",
 			"tracking_clients":             "tracking_clients",
@@ -292,6 +293,8 @@ func NewRedisExporter(uri string, opts Options) (*Exporter, error) {
 			"tracking_total_prefixes":                "tracking_total_prefixes",
 			"instantaneous_eventloop_cycles_per_sec": "instantaneous_eventloop_cycles_per_sec", // Added in Redis 7.0
 			"instantaneous_eventloop_duration_usec":  "instantaneous_eventloop_duration_usec",  // Added in Redis 7.0
+			"avg_pipeline_length":                    "client_processing_pipeline_length",      // Added in Redis 8.8
+			"slowlog_commands_time_ms_max":           "slowlog_commands_duration_seconds_max",  // Added in Redis 8.8
 
 			// # Replication
 			"connected_slaves":               "connected_slaves",
@@ -406,9 +409,15 @@ func NewRedisExporter(uri string, opts Options) (*Exporter, error) {
 			"keyspace_hits":                  "keyspace_hits_total",
 			"keyspace_misses":                "keyspace_misses_total",
 
-			"eventloop_cycles":           "eventloop_cycles_total",                // Added in Redis 7.0
-			"eventloop_duration_sum":     "eventloop_duration_sum_usec_total",     // Added in Redis 7.0
-			"eventloop_duration_cmd_sum": "eventloop_duration_cmd_sum_usec_total", // Added in Redis 7.0
+			"eventloop_cycles":                         "eventloop_cycles_total",                         // Added in Redis 7.0
+			"eventloop_duration_sum":                   "eventloop_duration_sum_usec_total",              // Added in Redis 7.0
+			"eventloop_duration_cmd_sum":               "eventloop_duration_cmd_sum_usec_total",          // Added in Redis 7.0
+			"eventloop_cycles_with_clients_processing": "eventloop_cycles_with_clients_processing_total", // Added in Redis 8.8
+			"total_client_processing_events":           "client_processing_events_total",                 // Added in Redis 8.8
+			"avg_pipeline_length_sum":                  "client_processing_pipeline_commands_total",      // Added in Redis 8.8
+			"avg_pipeline_length_cnt":                  "client_processing_pipeline_batches_total",       // Added in Redis 8.8
+			"slowlog_commands_count":                   "slowlog_commands_total",                         // Added in Redis 8.8
+			"slowlog_commands_time_ms_sum":             "slowlog_commands_duration_seconds_total",        // Added in Redis 8.8
 
 			"used_cpu_sys":              "cpu_sys_seconds_total",
 			"used_cpu_user":             "cpu_user_seconds_total",
@@ -527,7 +536,19 @@ func NewRedisExporter(uri string, opts Options) (*Exporter, error) {
 		"commands_failed_calls_total":                        {txt: `Total number of errors prior command execution per command`, lbls: []string{"cmd"}},
 		"commands_latencies_usec":                            {txt: `A histogram of latencies per command`, lbls: []string{"cmd"}},
 		"commands_rejected_calls_total":                      {txt: `Total number of errors within command execution per command`, lbls: []string{"cmd"}},
+		"commands_slowlog_duration_seconds_max":              {txt: `Maximum slowlogged command execution time in seconds per command`, lbls: []string{"cmd"}},
+		"commands_slowlog_duration_seconds_total":            {txt: `Total slowlogged command execution time in seconds per command`, lbls: []string{"cmd"}},
+		"commands_slowlog_total":                             {txt: `Total number of slowlogged calls per command`, lbls: []string{"cmd"}},
 		"commands_total":                                     {txt: `Total number of calls per command`, lbls: []string{"cmd"}},
+		"active_clients":                                     {txt: `Number of clients active in Redis's rolling activity window`},
+		"client_processing_events_total":                     {txt: `Total attempts to process client input buffers`},
+		"client_processing_pipeline_batches_total":           {txt: `Total client input parsing batches that parsed at least one command`},
+		"client_processing_pipeline_commands_total":          {txt: `Total commands parsed across client input parsing batches`},
+		"client_processing_pipeline_length":                  {txt: `Average number of commands parsed per client input parsing batch`},
+		"connected_client_pipeline_batches_total":            {txt: `Total input parsing batches that parsed at least one command for this client`, lbls: []string{"id", "name"}},
+		"connected_client_pipeline_commands_total":           {txt: `Total commands parsed across input parsing batches for this client`, lbls: []string{"id", "name"}},
+		"connected_client_read_events_total":                 {txt: `Total read events for this client`, lbls: []string{"id", "name"}},
+		"eventloop_cycles_with_clients_processing_total":     {txt: `Total event loop cycles that processed client input buffers`},
 		"config_client_output_buffer_limit_bytes":            {txt: `The configured buffer limits per class`, lbls: []string{"class", "limit"}},
 		"config_client_output_buffer_limit_overcome_seconds": {txt: `How long for buffer limits per class to be exceeded before replicas are dropped`, lbls: []string{"class", "limit"}},
 		"config_key_value":                                   {txt: `Config key and value`, lbls: []string{"key", "value"}},
@@ -617,6 +638,9 @@ func NewRedisExporter(uri string, opts Options) (*Exporter, error) {
 		"commandlog_slow_length":                             {txt: `Total entries in the slow command log`},
 		"slowlog_last_id":                                    {txt: `Last id of slowlog`},
 		"slowlog_length":                                     {txt: `Total slowlog`},
+		"slowlog_commands_duration_seconds_max":              {txt: `Maximum execution time in seconds among slowlogged commands`},
+		"slowlog_commands_duration_seconds_total":            {txt: `Total execution time in seconds of slowlogged commands`},
+		"slowlog_commands_total":                             {txt: `Total number of commands written to the slowlog`},
 		"start_time_seconds":                                 {txt: "Start time of the Redis instance since unix epoch in seconds."},
 		"stream_entries_added_total":                         {txt: "The count of all entries added to the stream during its lifetime", lbls: []string{"db", "stream"}},
 		"stream_first_entry_id":                              {txt: `The epoch timestamp (ms) of the first message in the stream`, lbls: []string{"db", "stream"}},
@@ -626,8 +650,15 @@ func NewRedisExporter(uri string, opts Options) (*Exporter, error) {
 		"stream_group_entries_read":                          {txt: `Total number of entries read from the stream group`, lbls: []string{"db", "stream", "group"}},
 		"stream_group_lag":                                   {txt: `The number of messages waiting to be delivered to the stream group's consumers`, lbls: []string{"db", "stream", "group"}},
 		"stream_group_last_delivered_id":                     {txt: `The epoch timestamp (ms) of the last delivered message`, lbls: []string{"db", "stream", "group"}},
+		"stream_group_messages_nacked":                       {txt: `Number of messages currently in the stream group's NACK zone`, lbls: []string{"db", "stream", "group"}},
 		"stream_group_messages_pending":                      {txt: `Pending number of messages in that stream group`, lbls: []string{"db", "stream", "group"}},
 		"stream_groups":                                      {txt: `Groups count of stream`, lbls: []string{"db", "stream"}},
+		"stream_idmp_duplicates_total":                       {txt: `Total duplicate idempotent IDs detected during the stream's lifetime`, lbls: []string{"db", "stream"}},
+		"stream_idmp_duration_seconds":                       {txt: `Duration in seconds that each idempotent ID is retained`, lbls: []string{"db", "stream"}},
+		"stream_idmp_entries_added_total":                    {txt: `Total stream entries added with an idempotent ID`, lbls: []string{"db", "stream"}},
+		"stream_idmp_idempotent_ids_tracked":                 {txt: `Number of idempotent IDs currently tracked by the stream`, lbls: []string{"db", "stream"}},
+		"stream_idmp_max_size":                               {txt: `Maximum recent idempotent IDs retained per producer ID`, lbls: []string{"db", "stream"}},
+		"stream_idmp_producer_ids_tracked":                   {txt: `Number of idempotent producer IDs currently tracked by the stream`, lbls: []string{"db", "stream"}},
 		"stream_last_entry_id":                               {txt: `The epoch timestamp (ms) of the last message in the stream`, lbls: []string{"db", "stream"}},
 		"stream_last_generated_id":                           {txt: `The epoch timestamp (ms) of the latest message on the stream`, lbls: []string{"db", "stream"}},
 		"stream_length":                                      {txt: `The number of elements of the stream`, lbls: []string{"db", "stream"}},
@@ -684,11 +715,15 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	}
 
 	for _, v := range e.metricMapGauges {
-		ch <- newMetricDescr(e.options.Namespace, v, v+" metric", nil)
+		if _, described := e.metricDescriptions[v]; !described {
+			ch <- newMetricDescr(e.options.Namespace, v, v+" metric", nil)
+		}
 	}
 
 	for _, v := range e.metricMapCounters {
-		ch <- newMetricDescr(e.options.Namespace, v, v+" metric", nil)
+		if _, described := e.metricDescriptions[v]; !described {
+			ch <- newMetricDescr(e.options.Namespace, v, v+" metric", nil)
+		}
 	}
 
 	ch <- e.totalScrapes.Desc()

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -331,6 +331,31 @@ func TestIncludeSystemMemoryMetric(t *testing.T) {
 	}
 }
 
+func TestDescribeEmitsMappedMetricsOnce(t *testing.T) {
+	e := getTestExporterWithOptions(t, Options{Namespace: "test"})
+	ch := make(chan *prometheus.Desc, 1000)
+	e.Describe(ch)
+	close(ch)
+
+	want := map[string]int{
+		"test_slowlog_commands_total":                  0,
+		"test_slowlog_commands_duration_seconds_total": 0,
+		"test_slowlog_commands_duration_seconds_max":   0,
+	}
+	for desc := range ch {
+		for name := range want {
+			if strings.Contains(desc.String(), `fqName: "`+name+`"`) {
+				want[name]++
+			}
+		}
+	}
+	for name, count := range want {
+		if count != 1 {
+			t.Errorf("Describe() emitted %s %d times, want once", name, count)
+		}
+	}
+}
+
 func TestIncludeConfigMetrics(t *testing.T) {
 	for _, inc := range []bool{false, true} {
 		e, _ := NewRedisExporter(os.Getenv("TEST_REDIS_URI"), Options{Namespace: "test", InclConfigMetrics: inc})

--- a/exporter/info.go
+++ b/exporter/info.go
@@ -464,6 +464,42 @@ func parseMetricsCommandStats(fieldKey string, fieldValue string) (cmd string, c
 	return
 }
 
+func parseMetricsCommandSlowlogStats(fieldValue string) (count float64, timeMsSum float64, timeMsMax float64, available bool, err error) {
+	var foundCount, foundTimeSum, foundTimeMax bool
+	for _, field := range strings.Split(fieldValue, ",") {
+		parts := strings.SplitN(field, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		var target *float64
+		switch parts[0] {
+		case "slowlog_count":
+			target = &count
+			foundCount = true
+		case "slowlog_time_ms_sum":
+			target = &timeMsSum
+			foundTimeSum = true
+		case "slowlog_time_ms_max":
+			target = &timeMsMax
+			foundTimeMax = true
+		default:
+			continue
+		}
+
+		*target, err = strconv.ParseFloat(parts[1], 64)
+		if err != nil {
+			return 0, 0, 0, false, fmt.Errorf("invalid %s: %w", parts[0], err)
+		}
+	}
+
+	available = foundCount || foundTimeSum || foundTimeMax
+	if available && !(foundCount && foundTimeSum && foundTimeMax) {
+		return 0, 0, 0, false, errors.New("incomplete command slowlog stats")
+	}
+	return
+}
+
 func parseMetricsLatencyStats(fieldKey string, fieldValue string) (cmd string, percentileMap map[float64]float64, errorOut error) {
 	/*
 		# Latencystats
@@ -556,6 +592,18 @@ func (e *Exporter) handleMetricsCommandStats(ch chan<- prometheus.Metric, fieldK
 		e.createMetricDescription("commands_failed_calls_total", []string{"cmd"})
 		e.registerConstMetric(ch, "commands_rejected_calls_total", rejectedCalls, prometheus.CounterValue, cmd)
 		e.registerConstMetric(ch, "commands_failed_calls_total", failedCalls, prometheus.CounterValue, cmd)
+	}
+
+	slowlogCount, slowlogTimeMsSum, slowlogTimeMsMax, slowlogStats, err := parseMetricsCommandSlowlogStats(fieldValue)
+	if err != nil {
+		log.Debugf("parseMetricsCommandSlowlogStats( %s ) err: %s", fieldValue, err)
+	} else if slowlogStats {
+		e.createMetricDescription("commands_slowlog_total", []string{"cmd"})
+		e.createMetricDescription("commands_slowlog_duration_seconds_total", []string{"cmd"})
+		e.createMetricDescription("commands_slowlog_duration_seconds_max", []string{"cmd"})
+		e.registerConstMetric(ch, "commands_slowlog_total", slowlogCount, prometheus.CounterValue, cmd)
+		e.registerConstMetric(ch, "commands_slowlog_duration_seconds_total", slowlogTimeMsSum/1e3, prometheus.CounterValue, cmd)
+		e.registerConstMetricGauge(ch, "commands_slowlog_duration_seconds_max", slowlogTimeMsMax/1e3, cmd)
 	}
 	return
 }

--- a/exporter/info.go
+++ b/exporter/info.go
@@ -494,7 +494,7 @@ func parseMetricsCommandSlowlogStats(fieldValue string) (count float64, timeMsSu
 	}
 
 	available = foundCount || foundTimeSum || foundTimeMax
-	if available && !(foundCount && foundTimeSum && foundTimeMax) {
+	if available && (!foundCount || !foundTimeSum || !foundTimeMax) {
 		return 0, 0, 0, false, errors.New("incomplete command slowlog stats")
 	}
 	return

--- a/exporter/info_test.go
+++ b/exporter/info_test.go
@@ -673,6 +673,22 @@ func Test_parseMetricsLatencyStats(t *testing.T) {
 	}
 }
 
+func TestHandleMetricsLatencyStats(t *testing.T) {
+	e := &Exporter{}
+	got := map[string]map[float64]float64{}
+
+	e.handleMetricsLatencyStats("latency_percentiles_usec_ping", "p50=0.001,p99=1.003", got)
+	want := map[string]map[float64]float64{"ping": {50: 0.001, 99: 1.003}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("handleMetricsLatencyStats() = %#v, want %#v", got, want)
+	}
+
+	e.handleMetricsLatencyStats("invalid", "p50=1", got)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("invalid latency stats changed the result: %#v", got)
+	}
+}
+
 // instance_info must survive a Valkey 8.0 -> 8.1 upgrade that adds the new
 // valkey_release_stage INFO field between scrapes, without a restart.
 func TestInstanceInfoLabelsChangeBetweenScrapes(t *testing.T) {

--- a/exporter/info_test.go
+++ b/exporter/info_test.go
@@ -409,7 +409,7 @@ func TestParseCommandSlowlogStats(t *testing.T) {
 		},
 		{
 			name:          "redis 8.8",
-			value:         "calls=2,usec=10,usec_per_call=5.00,rejected_calls=0,failed_calls=0,slowlog_count=2,slowlog_time_ms_sum=125.50,slowlog_time_ms_max=75.25",
+			value:         "calls=2,usec=10,usec_per_call=5.00,rejected_calls=0,failed_calls=0,ignored,slowlog_count=2,slowlog_time_ms_sum=125.50,slowlog_time_ms_max=75.25",
 			wantCount:     2,
 			wantSum:       125.5,
 			wantMax:       75.25,
@@ -435,6 +435,22 @@ func TestParseCommandSlowlogStats(t *testing.T) {
 				t.Errorf("parseMetricsCommandSlowlogStats() = (%v, %v, %v, %t), want (%v, %v, %v, %t)", count, sum, max, available, test.wantCount, test.wantSum, test.wantMax, test.wantAvailable)
 			}
 		})
+	}
+}
+
+func TestCommandStatsIgnoreMalformedSlowlogStats(t *testing.T) {
+	e := getTestExporterWithOptions(t, Options{Namespace: "test"})
+	ch := make(chan prometheus.Metric, 8)
+	cmd, calls, usec := e.handleMetricsCommandStats(ch, "cmdstat_get", "calls=2,usec=10,usec_per_call=5.00,rejected_calls=0,failed_calls=0,slowlog_count=2")
+	close(ch)
+
+	if cmd != "get" || calls != 2 || usec != 10 {
+		t.Fatalf("base command stats = (%q, %v, %v), want (get, 2, 10)", cmd, calls, usec)
+	}
+	for metric := range ch {
+		if strings.Contains(metric.Desc().String(), "commands_slowlog_") {
+			t.Errorf("malformed slowlog stats emitted a metric: %s", metric.Desc())
+		}
 	}
 }
 

--- a/exporter/info_test.go
+++ b/exporter/info_test.go
@@ -2,6 +2,7 @@ package exporter
 
 import (
 	"fmt"
+	"math"
 	"net/http/httptest"
 	"os"
 	"reflect"
@@ -10,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -391,6 +393,132 @@ func TestParseCommandStats(t *testing.T) {
 		})
 	}
 
+}
+
+func TestParseCommandSlowlogStats(t *testing.T) {
+	for _, test := range []struct {
+		name                        string
+		value                       string
+		wantCount, wantSum, wantMax float64
+		wantAvailable, wantError    bool
+	}{
+		{
+			name:          "absent",
+			value:         "calls=2,usec=10,usec_per_call=5.00,rejected_calls=0,failed_calls=0",
+			wantAvailable: false,
+		},
+		{
+			name:          "redis 8.8",
+			value:         "calls=2,usec=10,usec_per_call=5.00,rejected_calls=0,failed_calls=0,slowlog_count=2,slowlog_time_ms_sum=125.50,slowlog_time_ms_max=75.25",
+			wantCount:     2,
+			wantSum:       125.5,
+			wantMax:       75.25,
+			wantAvailable: true,
+		},
+		{
+			name:      "incomplete",
+			value:     "calls=2,slowlog_count=2",
+			wantError: true,
+		},
+		{
+			name:      "invalid",
+			value:     "calls=2,slowlog_count=nope,slowlog_time_ms_sum=1,slowlog_time_ms_max=1",
+			wantError: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			count, sum, max, available, err := parseMetricsCommandSlowlogStats(test.value)
+			if (err != nil) != test.wantError {
+				t.Fatalf("parseMetricsCommandSlowlogStats() err = %v, wantError %t", err, test.wantError)
+			}
+			if count != test.wantCount || sum != test.wantSum || max != test.wantMax || available != test.wantAvailable {
+				t.Errorf("parseMetricsCommandSlowlogStats() = (%v, %v, %v, %t), want (%v, %v, %v, %t)", count, sum, max, available, test.wantCount, test.wantSum, test.wantMax, test.wantAvailable)
+			}
+		})
+	}
+}
+
+func TestRedisEightEightInfoMetrics(t *testing.T) {
+	e, err := NewRedisExporter("redis://localhost:6379", Options{Namespace: "test"})
+	if err != nil {
+		t.Fatalf("NewRedisExporter() err: %s", err)
+	}
+	info := `# Clients
+active_clients:4
+# Stats
+eventloop_cycles_with_clients_processing:11
+total_client_processing_events:12
+avg_pipeline_length_sum:30
+avg_pipeline_length_cnt:10
+avg_pipeline_length:3.00
+slowlog_commands_count:7
+slowlog_commands_time_ms_max:400.00
+slowlog_commands_time_ms_sum:1250.00
+# Commandstats
+cmdstat_xnack:calls=4,usec=40,usec_per_call=10.00,rejected_calls=0,failed_calls=0,slowlog_count=2,slowlog_time_ms_sum=300.00,slowlog_time_ms_max=200.00
+`
+
+	type expectedMetric struct {
+		value   float64
+		counter bool
+		found   bool
+	}
+	want := map[string]*expectedMetric{
+		"active_clients": {value: 4},
+		"eventloop_cycles_with_clients_processing_total": {value: 11, counter: true},
+		"client_processing_events_total":                 {value: 12, counter: true},
+		"client_processing_pipeline_commands_total":      {value: 30, counter: true},
+		"client_processing_pipeline_batches_total":       {value: 10, counter: true},
+		"client_processing_pipeline_length":              {value: 3},
+		"slowlog_commands_total":                         {value: 7, counter: true},
+		"slowlog_commands_duration_seconds_max":          {value: 0.4},
+		"slowlog_commands_duration_seconds_total":        {value: 1.25, counter: true},
+		"commands_slowlog_total":                         {value: 2, counter: true},
+		"commands_slowlog_duration_seconds_total":        {value: 0.3, counter: true},
+		"commands_slowlog_duration_seconds_max":          {value: 0.2},
+	}
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		e.extractInfoMetrics(ch, info, 0)
+		close(ch)
+	}()
+	for metric := range ch {
+		desc := metric.Desc().String()
+		for name, expected := range want {
+			if !strings.Contains(desc, `fqName: "test_`+name+`"`) {
+				continue
+			}
+			var got dto.Metric
+			if err := metric.Write(&got); err != nil {
+				t.Fatalf("metric.Write(%s) err: %s", name, err)
+			}
+			var value float64
+			if expected.counter {
+				if got.Counter == nil {
+					t.Errorf("%s is not a counter", name)
+					continue
+				}
+				value = got.Counter.GetValue()
+			} else {
+				if got.Gauge == nil {
+					t.Errorf("%s is not a gauge", name)
+					continue
+				}
+				value = got.Gauge.GetValue()
+			}
+			if math.Abs(value-expected.value) > 1e-9 {
+				t.Errorf("%s value = %v, want %v", name, value, expected.value)
+			}
+			expected.found = true
+		}
+	}
+
+	for name, expected := range want {
+		if !expected.found {
+			t.Errorf("metric %s was not emitted", name)
+		}
+	}
 }
 
 func TestParseErrorStats(t *testing.T) {

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -88,6 +88,8 @@ func (e *Exporter) parseAndRegisterConstMetric(ch chan<- prometheus.Metric, fiel
 	case "latest_fork_usec":
 		metricName = "latest_fork_seconds"
 		val = val / 1e6
+	case "slowlog_commands_duration_seconds_max", "slowlog_commands_duration_seconds_total":
+		val /= 1e3
 	}
 
 	e.registerConstMetric(ch, metricName, val, t)

--- a/exporter/streams.go
+++ b/exporter/streams.go
@@ -1,6 +1,7 @@
 package exporter
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -19,6 +20,13 @@ type streamInfo struct {
 	Groups            int64  `redis:"groups"`
 	MaxDeletedEntryId string `redis:"max-deleted-entry-id"`
 	EntriesAdded      int64  `redis:"entries-added"`
+	IDMPDuration      int64  `redis:"idmp-duration"`
+	IDMPMaxSize       int64  `redis:"idmp-maxsize"`
+	PIDsTracked       int64  `redis:"pids-tracked"`
+	IIDsTracked       int64  `redis:"iids-tracked"`
+	IIDsAdded         int64  `redis:"iids-added"`
+	IIDsDuplicates    int64  `redis:"iids-duplicates"`
+	IDMPAvailable     bool
 	FirstEntryId      string
 	LastEntryId       string
 	StreamGroupsInfo  []streamGroupsInfo
@@ -31,6 +39,8 @@ type streamGroupsInfo struct {
 	LastDeliveredId          string `redis:"last-delivered-id"`
 	EntriesRead              int64  `redis:"entries-read"`
 	Lag                      int64  `redis:"lag"`
+	NackedCount              int64
+	NackedCountAvailable     bool
 	StreamGroupConsumersInfo []streamGroupConsumersInfo
 }
 
@@ -46,32 +56,55 @@ func getStreamInfo(c redis.Conn, key string) (*streamInfo, error) {
 		return nil, err
 	}
 
-	// Scan slice to struct
-	var stream streamInfo
-	if err := redis.ScanStruct(values, &stream); err != nil {
+	stream, err := parseStreamInfo(values)
+	if err != nil {
 		return nil, err
-	}
-
-	// Extract first and last id from slice
-	for idx, v := range values {
-		vbytes, ok := v.([]byte)
-		if !ok {
-			continue
-		}
-		if string(vbytes) == "first-entry" {
-			stream.FirstEntryId = getStreamEntryId(values, idx+1)
-		}
-		if string(vbytes) == "last-entry" {
-			stream.LastEntryId = getStreamEntryId(values, idx+1)
-		}
 	}
 
 	stream.StreamGroupsInfo, err = scanStreamGroups(c, key)
 	if err != nil {
 		return nil, err
 	}
+	if len(stream.StreamGroupsInfo) > 0 {
+		nackedCounts, err := scanStreamGroupNackedCounts(c, key)
+		if err != nil {
+			log.Debugf("Couldn't get XNACK state for stream '%s': %s", key, err)
+		} else {
+			for idx := range stream.StreamGroupsInfo {
+				group := &stream.StreamGroupsInfo[idx]
+				if count, ok := nackedCounts[group.Name]; ok {
+					group.NackedCount = count
+					group.NackedCountAvailable = true
+				}
+			}
+		}
+	}
 
-	log.Debugf("getStreamInfo() stream: %#v", &stream)
+	log.Debugf("getStreamInfo() stream: %#v", stream)
+	return stream, nil
+}
+
+func parseStreamInfo(values []any) (*streamInfo, error) {
+	var stream streamInfo
+	if err := redis.ScanStruct(values, &stream); err != nil {
+		return nil, err
+	}
+
+	for idx := 0; idx+1 < len(values); idx += 2 {
+		key, err := redis.String(values[idx], nil)
+		if err != nil {
+			continue
+		}
+		switch key {
+		case "first-entry":
+			stream.FirstEntryId = getStreamEntryId(values, idx+1)
+		case "last-entry":
+			stream.LastEntryId = getStreamEntryId(values, idx+1)
+		case "idmp-duration":
+			stream.IDMPAvailable = true
+		}
+	}
+
 	return &stream, nil
 }
 
@@ -128,6 +161,61 @@ func scanStreamGroups(c redis.Conn, stream string) ([]streamGroupsInfo, error) {
 	return result, nil
 }
 
+func scanStreamGroupNackedCounts(c redis.Conn, stream string) (map[string]int64, error) {
+	values, err := redis.Values(doRedisCmd(c, "XINFO", "STREAM", stream, "FULL", "COUNT", 1))
+	if err != nil {
+		return nil, err
+	}
+	return parseStreamGroupNackedCounts(values)
+}
+
+func parseStreamGroupNackedCounts(values []any) (map[string]int64, error) {
+	result := map[string]int64{}
+	var groups []any
+	for idx := 0; idx+1 < len(values); idx += 2 {
+		key, err := redis.String(values[idx], nil)
+		if err != nil || key != "groups" {
+			continue
+		}
+		groups, err = redis.Values(values[idx+1], nil)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't parse stream groups: %w", err)
+		}
+		break
+	}
+
+	for _, rawGroup := range groups {
+		fields, err := redis.Values(rawGroup, nil)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't parse stream group: %w", err)
+		}
+		var name string
+		var nackedCount int64
+		var nackedCountAvailable bool
+		for idx := 0; idx+1 < len(fields); idx += 2 {
+			key, err := redis.String(fields[idx], nil)
+			if err != nil {
+				continue
+			}
+			switch key {
+			case "name":
+				name, err = redis.String(fields[idx+1], nil)
+			case "nacked-count":
+				nackedCount, err = redis.Int64(fields[idx+1], nil)
+				nackedCountAvailable = err == nil
+			}
+			if err != nil {
+				return nil, fmt.Errorf("couldn't parse stream group field %q: %w", key, err)
+			}
+		}
+		if name != "" && nackedCountAvailable {
+			result[name] = nackedCount
+		}
+	}
+
+	return result, nil
+}
+
 func scanStreamGroupConsumers(c redis.Conn, stream string, group string) ([]streamGroupConsumersInfo, error) {
 	consumers, err := redis.Values(doRedisCmd(c, "XINFO", "CONSUMERS", stream, group))
 	if err != nil {
@@ -173,6 +261,44 @@ func parseStreamItemId(id string) float64 {
 	return parsedId
 }
 
+func (e *Exporter) registerStreamMetrics(ch chan<- prometheus.Metric, dbLabel string, key string, info *streamInfo) {
+	e.registerConstMetricGauge(ch, "stream_length", float64(info.Length), dbLabel, key)
+	e.registerConstMetricGauge(ch, "stream_radix_tree_keys", float64(info.RadixTreeKeys), dbLabel, key)
+	e.registerConstMetricGauge(ch, "stream_radix_tree_nodes", float64(info.RadixTreeNodes), dbLabel, key)
+	e.registerConstMetricGauge(ch, "stream_last_generated_id", parseStreamItemId(info.LastGeneratedId), dbLabel, key)
+	e.registerConstMetricGauge(ch, "stream_groups", float64(info.Groups), dbLabel, key)
+	e.registerConstMetricGauge(ch, "stream_max_deleted_entry_id", parseStreamItemId(info.MaxDeletedEntryId), dbLabel, key)
+	e.registerConstMetricGauge(ch, "stream_first_entry_id", parseStreamItemId(info.FirstEntryId), dbLabel, key)
+	e.registerConstMetricGauge(ch, "stream_last_entry_id", parseStreamItemId(info.LastEntryId), dbLabel, key)
+	e.registerConstMetric(ch, "stream_entries_added_total", float64(info.EntriesAdded), prometheus.CounterValue, dbLabel, key)
+
+	if info.IDMPAvailable {
+		e.registerConstMetricGauge(ch, "stream_idmp_duration_seconds", float64(info.IDMPDuration), dbLabel, key)
+		e.registerConstMetricGauge(ch, "stream_idmp_max_size", float64(info.IDMPMaxSize), dbLabel, key)
+		e.registerConstMetricGauge(ch, "stream_idmp_producer_ids_tracked", float64(info.PIDsTracked), dbLabel, key)
+		e.registerConstMetricGauge(ch, "stream_idmp_idempotent_ids_tracked", float64(info.IIDsTracked), dbLabel, key)
+		e.registerConstMetric(ch, "stream_idmp_entries_added_total", float64(info.IIDsAdded), prometheus.CounterValue, dbLabel, key)
+		e.registerConstMetric(ch, "stream_idmp_duplicates_total", float64(info.IIDsDuplicates), prometheus.CounterValue, dbLabel, key)
+	}
+
+	for _, group := range info.StreamGroupsInfo {
+		e.registerConstMetricGauge(ch, "stream_group_consumers", float64(group.Consumers), dbLabel, key, group.Name)
+		e.registerConstMetricGauge(ch, "stream_group_messages_pending", float64(group.Pending), dbLabel, key, group.Name)
+		e.registerConstMetricGauge(ch, "stream_group_last_delivered_id", parseStreamItemId(group.LastDeliveredId), dbLabel, key, group.Name)
+		e.registerConstMetricGauge(ch, "stream_group_entries_read", float64(group.EntriesRead), dbLabel, key, group.Name)
+		e.registerConstMetricGauge(ch, "stream_group_lag", float64(group.Lag), dbLabel, key, group.Name)
+		if group.NackedCountAvailable {
+			e.registerConstMetricGauge(ch, "stream_group_messages_nacked", float64(group.NackedCount), dbLabel, key, group.Name)
+		}
+		if !e.options.StreamsExcludeConsumerMetrics {
+			for _, consumer := range group.StreamGroupConsumersInfo {
+				e.registerConstMetricGauge(ch, "stream_group_consumer_messages_pending", float64(consumer.Pending), dbLabel, key, group.Name, consumer.Name)
+				e.registerConstMetricGauge(ch, "stream_group_consumer_idle_seconds", float64(consumer.Idle)/1e3, dbLabel, key, group.Name, consumer.Name)
+			}
+		}
+	}
+}
+
 func (e *Exporter) extractStreamMetrics(ch chan<- prometheus.Metric, c redis.Conn) {
 	streams, err := parseKeyArg(e.options.CheckStreams)
 	if err != nil {
@@ -206,29 +332,6 @@ func (e *Exporter) extractStreamMetrics(ch chan<- prometheus.Metric, c redis.Con
 			continue
 		}
 		dbLabel := "db" + k.db
-
-		e.registerConstMetricGauge(ch, "stream_length", float64(info.Length), dbLabel, k.key)
-		e.registerConstMetricGauge(ch, "stream_radix_tree_keys", float64(info.RadixTreeKeys), dbLabel, k.key)
-		e.registerConstMetricGauge(ch, "stream_radix_tree_nodes", float64(info.RadixTreeNodes), dbLabel, k.key)
-		e.registerConstMetricGauge(ch, "stream_last_generated_id", parseStreamItemId(info.LastGeneratedId), dbLabel, k.key)
-		e.registerConstMetricGauge(ch, "stream_groups", float64(info.Groups), dbLabel, k.key)
-		e.registerConstMetricGauge(ch, "stream_max_deleted_entry_id", parseStreamItemId(info.MaxDeletedEntryId), dbLabel, k.key)
-		e.registerConstMetricGauge(ch, "stream_first_entry_id", parseStreamItemId(info.FirstEntryId), dbLabel, k.key)
-		e.registerConstMetricGauge(ch, "stream_last_entry_id", parseStreamItemId(info.LastEntryId), dbLabel, k.key)
-		e.registerConstMetric(ch, "stream_entries_added_total", float64(info.EntriesAdded), prometheus.CounterValue, dbLabel, k.key)
-
-		for _, g := range info.StreamGroupsInfo {
-			e.registerConstMetricGauge(ch, "stream_group_consumers", float64(g.Consumers), dbLabel, k.key, g.Name)
-			e.registerConstMetricGauge(ch, "stream_group_messages_pending", float64(g.Pending), dbLabel, k.key, g.Name)
-			e.registerConstMetricGauge(ch, "stream_group_last_delivered_id", parseStreamItemId(g.LastDeliveredId), dbLabel, k.key, g.Name)
-			e.registerConstMetricGauge(ch, "stream_group_entries_read", float64(g.EntriesRead), dbLabel, k.key, g.Name)
-			e.registerConstMetricGauge(ch, "stream_group_lag", float64(g.Lag), dbLabel, k.key, g.Name)
-			if !e.options.StreamsExcludeConsumerMetrics {
-				for _, c := range g.StreamGroupConsumersInfo {
-					e.registerConstMetricGauge(ch, "stream_group_consumer_messages_pending", float64(c.Pending), dbLabel, k.key, g.Name, c.Name)
-					e.registerConstMetricGauge(ch, "stream_group_consumer_idle_seconds", float64(c.Idle)/1e3, dbLabel, k.key, g.Name, c.Name)
-				}
-			}
-		}
+		e.registerStreamMetrics(ch, dbLabel, k.key, info)
 	}
 }

--- a/exporter/streams_test.go
+++ b/exporter/streams_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gomodule/redigo/redis"
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -33,6 +34,147 @@ func isNotTestTimestamp(returned string) bool {
 		}
 	}
 	return true
+}
+
+func TestParseRedisIDMPStreamInfo(t *testing.T) {
+	values := []any{
+		[]byte("length"), int64(2),
+		[]byte("last-generated-id"), []byte("1638006862417-2"),
+		[]byte("idmp-duration"), int64(60),
+		[]byte("idmp-maxsize"), int64(100),
+		[]byte("pids-tracked"), int64(3),
+		[]byte("iids-tracked"), int64(7),
+		[]byte("iids-added"), int64(11),
+		[]byte("iids-duplicates"), int64(2),
+		[]byte("first-entry"), []any{[]byte("1638006862416-0"), []any{}},
+		[]byte("last-entry"), []any{[]byte("1638006862417-2"), []any{}},
+	}
+
+	info, err := parseStreamInfo(values)
+	if err != nil {
+		t.Fatalf("parseStreamInfo() err: %s", err)
+	}
+	if !info.IDMPAvailable {
+		t.Fatal("IDMP fields were not marked available")
+	}
+	if info.IDMPDuration != 60 || info.IDMPMaxSize != 100 || info.PIDsTracked != 3 || info.IIDsTracked != 7 || info.IIDsAdded != 11 || info.IIDsDuplicates != 2 {
+		t.Errorf("unexpected IDMP stream info: %#v", info)
+	}
+	if info.FirstEntryId != "1638006862416-0" || info.LastEntryId != "1638006862417-2" {
+		t.Errorf("unexpected stream entry IDs: first=%q last=%q", info.FirstEntryId, info.LastEntryId)
+	}
+}
+
+func TestParseStreamGroupNackedCounts(t *testing.T) {
+	values := []any{
+		[]byte("length"), int64(3),
+		[]byte("groups"), []any{
+			[]any{[]byte("name"), []byte("workers"), []byte("nacked-count"), int64(2)},
+			[]any{[]byte("name"), []byte("other"), []byte("nacked-count"), int64(0)},
+			[]any{[]byte("name"), []byte("pre-8.8")},
+		},
+	}
+
+	got, err := parseStreamGroupNackedCounts(values)
+	if err != nil {
+		t.Fatalf("parseStreamGroupNackedCounts() err: %s", err)
+	}
+	if len(got) != 2 || got["workers"] != 2 || got["other"] != 0 {
+		t.Errorf("parseStreamGroupNackedCounts() = %#v, want workers=2 and other=0", got)
+	}
+}
+
+func TestRedisIDMPAndXNACKStreamMetrics(t *testing.T) {
+	e, err := NewRedisExporter("redis://localhost:6379", Options{Namespace: "test"})
+	if err != nil {
+		t.Fatalf("NewRedisExporter() err: %s", err)
+	}
+	info := &streamInfo{
+		IDMPAvailable:  true,
+		IDMPDuration:   60,
+		IDMPMaxSize:    100,
+		PIDsTracked:    3,
+		IIDsTracked:    7,
+		IIDsAdded:      11,
+		IIDsDuplicates: 2,
+		StreamGroupsInfo: []streamGroupsInfo{{
+			Name: "workers", NackedCount: 2, NackedCountAvailable: true,
+		}},
+	}
+	type expectedMetric struct {
+		value   float64
+		counter bool
+		found   bool
+	}
+	want := map[string]*expectedMetric{
+		"stream_idmp_duration_seconds":       {value: 60},
+		"stream_idmp_max_size":               {value: 100},
+		"stream_idmp_producer_ids_tracked":   {value: 3},
+		"stream_idmp_idempotent_ids_tracked": {value: 7},
+		"stream_idmp_entries_added_total":    {value: 11, counter: true},
+		"stream_idmp_duplicates_total":       {value: 2, counter: true},
+		"stream_group_messages_nacked":       {value: 2},
+	}
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		e.registerStreamMetrics(ch, "db0", "events", info)
+		close(ch)
+	}()
+	for metric := range ch {
+		for name, expected := range want {
+			if !strings.Contains(metric.Desc().String(), `fqName: "test_`+name+`"`) {
+				continue
+			}
+			var got dto.Metric
+			if err := metric.Write(&got); err != nil {
+				t.Fatalf("metric.Write(%s) err: %s", name, err)
+			}
+			var value float64
+			if expected.counter {
+				if got.Counter == nil {
+					t.Errorf("%s is not a counter", name)
+					continue
+				}
+				value = got.Counter.GetValue()
+			} else {
+				if got.Gauge == nil {
+					t.Errorf("%s is not a gauge", name)
+					continue
+				}
+				value = got.Gauge.GetValue()
+			}
+			if value != expected.value {
+				t.Errorf("%s value = %v, want %v", name, value, expected.value)
+			}
+			expected.found = true
+		}
+	}
+	for name, expected := range want {
+		if !expected.found {
+			t.Errorf("metric %s was not emitted", name)
+		}
+	}
+}
+
+func TestStreamMetricsOmitUnavailableIDMPAndXNACKState(t *testing.T) {
+	e, err := NewRedisExporter("redis://localhost:6379", Options{Namespace: "test"})
+	if err != nil {
+		t.Fatalf("NewRedisExporter() err: %s", err)
+	}
+	info := &streamInfo{StreamGroupsInfo: []streamGroupsInfo{{Name: "workers"}}}
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		e.registerStreamMetrics(ch, "db0", "events", info)
+		close(ch)
+	}()
+	for metric := range ch {
+		desc := metric.Desc().String()
+		if strings.Contains(desc, "stream_idmp_") || strings.Contains(desc, "stream_group_messages_nacked") {
+			t.Errorf("unsupported stream state was emitted: %s", desc)
+		}
+	}
 }
 
 func TestStreamsGetStreamInfo(t *testing.T) {

--- a/exporter/streams_test.go
+++ b/exporter/streams_test.go
@@ -1,8 +1,10 @@
 package exporter
 
 import (
+	"errors"
 	"net/http/httptest"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -19,6 +21,31 @@ type scanStreamFixture struct {
 	groups     []streamGroupsInfo
 	consumers  []streamGroupConsumersInfo
 }
+
+type redisReply struct {
+	value any
+	err   error
+}
+
+type queuedRedisConn struct {
+	replies []redisReply
+	calls   [][]any
+}
+
+func (c *queuedRedisConn) Close() error { return nil }
+func (c *queuedRedisConn) Err() error   { return nil }
+func (c *queuedRedisConn) Do(commandName string, args ...any) (any, error) {
+	c.calls = append(c.calls, append([]any{commandName}, args...))
+	if len(c.replies) == 0 {
+		return nil, errors.New("unexpected Redis command")
+	}
+	reply := c.replies[0]
+	c.replies = c.replies[1:]
+	return reply.value, reply.err
+}
+func (c *queuedRedisConn) Send(string, ...any) error { return nil }
+func (c *queuedRedisConn) Flush() error              { return nil }
+func (c *queuedRedisConn) Receive() (any, error)     { return nil, nil }
 
 var (
 	TestStreamTimestamps = []string{
@@ -38,6 +65,7 @@ func isNotTestTimestamp(returned string) bool {
 
 func TestParseRedisIDMPStreamInfo(t *testing.T) {
 	values := []any{
+		nil, nil,
 		[]byte("length"), int64(2),
 		[]byte("last-generated-id"), []byte("1638006862417-2"),
 		[]byte("idmp-duration"), int64(60),
@@ -65,11 +93,18 @@ func TestParseRedisIDMPStreamInfo(t *testing.T) {
 	}
 }
 
+func TestParseStreamInfoRejectsMalformedReply(t *testing.T) {
+	if _, err := parseStreamInfo([]any{[]byte("length")}); err == nil {
+		t.Fatal("parseStreamInfo() expected an error for an odd-length reply")
+	}
+}
+
 func TestParseStreamGroupNackedCounts(t *testing.T) {
 	values := []any{
+		nil, nil,
 		[]byte("length"), int64(3),
 		[]byte("groups"), []any{
-			[]any{[]byte("name"), []byte("workers"), []byte("nacked-count"), int64(2)},
+			[]any{nil, nil, []byte("name"), []byte("workers"), []byte("nacked-count"), int64(2)},
 			[]any{[]byte("name"), []byte("other"), []byte("nacked-count"), int64(0)},
 			[]any{[]byte("name"), []byte("pre-8.8")},
 		},
@@ -81,6 +116,72 @@ func TestParseStreamGroupNackedCounts(t *testing.T) {
 	}
 	if len(got) != 2 || got["workers"] != 2 || got["other"] != 0 {
 		t.Errorf("parseStreamGroupNackedCounts() = %#v, want workers=2 and other=0", got)
+	}
+}
+
+func TestParseStreamGroupNackedCountsErrors(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		values []any
+	}{
+		{name: "invalid groups", values: []any{[]byte("groups"), int64(1)}},
+		{name: "invalid group", values: []any{[]byte("groups"), []any{int64(1)}}},
+		{name: "invalid name", values: []any{[]byte("groups"), []any{[]any{[]byte("name"), int64(1)}}}},
+		{name: "invalid nacked count", values: []any{[]byte("groups"), []any{[]any{[]byte("name"), []byte("workers"), []byte("nacked-count"), []byte("bad")}}}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := parseStreamGroupNackedCounts(test.values); err == nil {
+				t.Fatal("parseStreamGroupNackedCounts() expected an error")
+			}
+		})
+	}
+}
+
+func TestGetStreamInfoRedisEightEight(t *testing.T) {
+	conn := &queuedRedisConn{replies: []redisReply{
+		{value: []any{[]byte("length"), int64(2), []byte("groups"), int64(1), []byte("idmp-duration"), int64(60)}},
+		{value: []any{[]any{[]byte("name"), []byte("workers"), []byte("consumers"), int64(0)}}},
+		{value: []any{}},
+		{value: []any{[]byte("groups"), []any{[]any{[]byte("name"), []byte("workers"), []byte("nacked-count"), int64(2)}}}},
+	}}
+
+	info, err := getStreamInfo(conn, "events")
+	if err != nil {
+		t.Fatalf("getStreamInfo() err: %s", err)
+	}
+	if !info.IDMPAvailable || len(info.StreamGroupsInfo) != 1 || !info.StreamGroupsInfo[0].NackedCountAvailable || info.StreamGroupsInfo[0].NackedCount != 2 {
+		t.Fatalf("unexpected Redis 8.8 stream info: %#v", info)
+	}
+	wantFullCall := []any{"XINFO", "STREAM", "events", "FULL", "COUNT", 1}
+	if !reflect.DeepEqual(conn.calls[len(conn.calls)-1], wantFullCall) {
+		t.Errorf("last Redis call = %#v, want %#v", conn.calls[len(conn.calls)-1], wantFullCall)
+	}
+}
+
+func TestGetStreamInfoErrorsAndFallbacks(t *testing.T) {
+	errRedis := errors.New("redis error")
+	streamReply := []any{[]byte("length"), int64(2), []byte("groups"), int64(1)}
+	groupsReply := []any{[]any{[]byte("name"), []byte("workers"), []byte("consumers"), int64(0)}}
+	for _, test := range []struct {
+		name      string
+		replies   []redisReply
+		wantError bool
+	}{
+		{name: "stream command", replies: []redisReply{{err: errRedis}}, wantError: true},
+		{name: "malformed stream", replies: []redisReply{{value: []any{[]byte("length")}}}, wantError: true},
+		{name: "groups command", replies: []redisReply{{value: streamReply}, {err: errRedis}}, wantError: true},
+		{name: "no groups", replies: []redisReply{{value: []any{[]byte("length"), int64(2), []byte("groups"), int64(0)}}, {value: []any{}}}},
+		{name: "full unavailable", replies: []redisReply{{value: streamReply}, {value: groupsReply}, {value: []any{}}, {err: errRedis}}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			info, err := getStreamInfo(&queuedRedisConn{replies: test.replies}, "events")
+			if (err != nil) != test.wantError {
+				t.Fatalf("getStreamInfo() err = %v, wantError %t", err, test.wantError)
+			}
+			if err == nil && len(info.StreamGroupsInfo) > 0 && info.StreamGroupsInfo[0].NackedCountAvailable {
+				t.Errorf("fallback unexpectedly marked XNACK state available: %#v", info.StreamGroupsInfo[0])
+			}
+		})
 	}
 }
 
@@ -99,6 +200,7 @@ func TestRedisIDMPAndXNACKStreamMetrics(t *testing.T) {
 		IIDsDuplicates: 2,
 		StreamGroupsInfo: []streamGroupsInfo{{
 			Name: "workers", NackedCount: 2, NackedCountAvailable: true,
+			StreamGroupConsumersInfo: []streamGroupConsumersInfo{{Name: "worker-1", Pending: 4, Idle: 1500}},
 		}},
 	}
 	type expectedMetric struct {
@@ -107,13 +209,15 @@ func TestRedisIDMPAndXNACKStreamMetrics(t *testing.T) {
 		found   bool
 	}
 	want := map[string]*expectedMetric{
-		"stream_idmp_duration_seconds":       {value: 60},
-		"stream_idmp_max_size":               {value: 100},
-		"stream_idmp_producer_ids_tracked":   {value: 3},
-		"stream_idmp_idempotent_ids_tracked": {value: 7},
-		"stream_idmp_entries_added_total":    {value: 11, counter: true},
-		"stream_idmp_duplicates_total":       {value: 2, counter: true},
-		"stream_group_messages_nacked":       {value: 2},
+		"stream_idmp_duration_seconds":           {value: 60},
+		"stream_idmp_max_size":                   {value: 100},
+		"stream_idmp_producer_ids_tracked":       {value: 3},
+		"stream_idmp_idempotent_ids_tracked":     {value: 7},
+		"stream_idmp_entries_added_total":        {value: 11, counter: true},
+		"stream_idmp_duplicates_total":           {value: 2, counter: true},
+		"stream_group_messages_nacked":           {value: 2},
+		"stream_group_consumer_messages_pending": {value: 4},
+		"stream_group_consumer_idle_seconds":     {value: 1.5},
 	}
 
 	ch := make(chan prometheus.Metric)


### PR DESCRIPTION
## Summary
- export Redis 8.8 global and per-command slowlog metrics
- export global and per-client processing metrics
- export stream IDMP metrics and per-group XNACK state
- omit unsupported stream fields on older servers

## Verification
- focused Go tests
- `go vet ./...`
- live scrape against Redis 8.8