### PR TITLE
fix: connectToRedis() fallback dials the URL scheme instead of tcp

### DIFF
--- a/exporter/redis.go
+++ b/exporter/redis.go
@@ -76,13 +76,15 @@ func (e *Exporter) connectToRedis() (redis.Conn, error) {
 	c, err := redis.DialURL(uri, options...)
 	if err != nil {
 		log.Debugf("DialURL() failed, err: %s", err)
-		if frags := strings.Split(e.redisAddr, "://"); len(frags) == 2 {
-			log.Debugf("Trying: Dial(): %s %s", frags[0], frags[1])
-			c, err = redis.Dial(frags[0], frags[1], options...)
-		} else {
-			log.Debugf("Trying: Dial(): tcp %s", e.redisAddr)
-			c, err = redis.Dial("tcp", e.redisAddr, options...)
+		// Always dial "tcp" here — TLS comes from the DialUseTLS option,
+		// not the network type. Parse via url.Host (not a plain string
+		// split) so any embedded user:pass@ is stripped too.
+		addr := e.redisAddr
+		if u, parseErr := url.Parse(uri); parseErr == nil && u.Host != "" {
+			addr = u.Host
 		}
+		log.Debugf("Trying: Dial(): tcp %s", addr)
+		c, err = redis.Dial("tcp", addr, options...)
 	}
 	return c, err
 }

--- a/exporter/redis_test.go
+++ b/exporter/redis_test.go
@@ -109,7 +109,10 @@ func TestPasswordInvalid(t *testing.T) {
 	ts := httptest.NewServer(e)
 	defer ts.Close()
 
-	want := `test_exporter_last_scrape_error{err="dial redis: unknown network redis"} 1`
+	// was "dial redis: unknown network redis" — a fallback bug masking
+	// the real error, see connectToRedis(). Now surfaces the actual
+	// auth failure.
+	want := `test_exporter_last_scrape_error{err="NOAUTH Authentication required."} 1`
 	body := downloadURL(t, ts.URL+"/metrics")
 	if !strings.Contains(body, want) {
 		t.Errorf(`error, expected string "%s" in body, got body: \n\n%s`, want, body)

--- a/exporter/tls_test.go
+++ b/exporter/tls_test.go
@@ -190,6 +190,36 @@ func TestVerifiedIPTargetFailsWithoutTLSServerName(t *testing.T) {
 	}
 }
 
+// Regression test: when DialURL() fails on a rediss:// target (e.g. bad
+// credentials), connectToRedis()'s fallback used to split the address on
+// "://" and dial with the scheme itself as the network type, producing
+// "unknown network rediss" instead of the real error. It should always
+// dial "tcp" — TLS is handled via the DialUseTLS option, not the network
+// string. Related: #362, #478, #387.
+func TestConnectToRedisFallbackDialsTCPNotScheme(t *testing.T) {
+	addr, caCertFile, _ := startTinyRedisTLSServer(t)
+
+	e, err := NewRedisExporter("rediss://"+addr, Options{
+		Password:      "wrong-password",
+		CaCertFile:    caCertFile,
+		TLSServerName: "localhost",
+	})
+	if err != nil {
+		t.Fatalf("NewRedisExporter() err: %s", err)
+	}
+
+	_, err = e.connectToRedis()
+	if err == nil {
+		t.Fatal("connectToRedis() succeeded, want auth failure")
+	}
+	if strings.Contains(err.Error(), "unknown network") {
+		t.Fatalf("connectToRedis() err = %q, fallback dialed the scheme instead of tcp", err)
+	}
+	if !strings.Contains(err.Error(), "WRONGPASS") {
+		t.Fatalf("connectToRedis() err = %q, want the real WRONGPASS from the server", err)
+	}
+}
+
 func startTinyRedisTLSServer(t *testing.T) (string, string, <-chan string) {
 	t.Helper()
 
@@ -342,6 +372,9 @@ func serveTinyRedisConnection(conn net.Conn) {
 		}
 
 		switch strings.ToUpper(args[0]) {
+		case "AUTH":
+			// mirrors real Redis's rejection for a bad password
+			_, _ = conn.Write([]byte("-WRONGPASS invalid username-password pair or user is disabled.\r\n"))
 		case "INFO":
 			_, _ = conn.Write([]byte("$" + strconv.Itoa(len(tinyRedisInfo)) + "\r\n" + tinyRedisInfo + "\r\n"))
 		case "SLOWLOG":


### PR DESCRIPTION
## The bug

When `DialURL()` fails for any reason (bad credentials, connection reset, etc.), `connectToRedis()`'s fallback splits the target address on `"://"` and passes the scheme itself — e.g. `"rediss"` — as the dial **network type**:

```go
c, err = redis.Dial(frags[0], frags[1], options...)
```

Go's `net` package has no `"rediss"` (or `"redis"`) network, so this always fails immediately with a misleading `unknown network rediss` error — instead of surfacing whatever `DialURL()`'s real error was.

This isn't cosmetic: it means the exporter can never report a real reason when a `rediss://` target fails to authenticate. A genuine `WRONGPASS`/`NOAUTH` gets hidden behind "unknown network", which reads as a library/scheme problem rather than what it actually is — a credential problem. `TestPasswordInvalid` had (unintentionally) encoded this masked error as the expected behavior.

## The fix

TLS is already applied via the `DialUseTLS()` option in `configureOptions()`, independent of this fallback — the network type here should always be `"tcp"`, same as the no-scheme branch just below it. Also switched from a raw string split to parsing the address via `url.Host`, which additionally strips any embedded `user:pass@` — a raw split left that attached to the address, which broke the fallback in a different way (`too many colons in address`) once the scheme bug itself was fixed. Caught this via `TestPasswordInvalid`, which targets exactly that kind of address.

Before → after, same failure:

```
# before
dial rediss: unknown network rediss

# after
NOAUTH Authentication required.
```

## Testing

- `golangci-lint v2.11.2 --tests=false`: 0 issues
- `go vet ./...` + `gofmt -l`: clean
- Full `make test` against all real fixtures (fresh containers): 0 failures
- `go test -race`: clean
- Added `TestConnectToRedisFallbackDialsTCPNotScheme`, self-contained   (uses the existing tiny TLS test-server helper, no docker-compose changes) — exercises a `DialURL()` failure on a `rediss://` target and asserts the fallback reaches the server instead of dying on `"unknown network"`.
- Updated `TestPasswordInvalid`'s expectation to the real `NOAUTH` error it now surfaces, instead of the old masked one.
- Verified against a real production Redis Cluster (TLS + auth) as well as a real plain, password-protected instance — both now report the actual underlying error instead of "unknown network".

Related: #362, #478, #387 (same underlying symptom reported independently).