### PR TITLE
bad tls password test

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       --tls-cert-file     /tls/redis.crt
       --tls-key-file      /tls/redis.key
       --tls-ca-cert-file  /tls/ca.crt
+      --user exporter on '>exporter-password' '~*' '&*' '+@all'
     ports:
       - "16386:6379"
 

--- a/exporter/redis_connection_test.go
+++ b/exporter/redis_connection_test.go
@@ -118,3 +118,62 @@ func TestConnectToRedisURLDatabase(t *testing.T) {
 		})
 	}
 }
+
+func TestConnectToRedisTLSBadPassword(t *testing.T) {
+	uri := os.Getenv("TEST_VALKEY9_TLS_URI")
+	if uri == "" {
+		t.Skip("TEST_VALKEY9_TLS_URI not set")
+	}
+	u, err := url.Parse(uri)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tst := range []struct {
+		name          string
+		password      string
+		urlPassword   bool
+		wantWrongPass bool
+	}{
+		{name: "valid-url", password: "exporter-password", urlPassword: true},
+		{name: "invalid-url", password: "wrong-password", urlPassword: true, wantWrongPass: true},
+		{name: "valid-options", password: "exporter-password"},
+		{name: "invalid-options", password: "wrong-password", wantWrongPass: true},
+	} {
+		t.Run(tst.name, func(t *testing.T) {
+			target := *u
+			opts := Options{
+				Namespace:           "test",
+				ConnectionTimeouts:  time.Second,
+				SkipTLSVerification: true,
+				ClientCertFile:      "../contrib/tls/redis.crt",
+				ClientKeyFile:       "../contrib/tls/redis.key",
+			}
+			if tst.urlPassword {
+				target.User = url.UserPassword("exporter", tst.password)
+			} else {
+				opts.User = "exporter"
+				opts.Password = tst.password
+			}
+			e, err := NewRedisExporter(target.String(), opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !tst.wantWrongPass {
+				requireConnectionTestPing(t, e)
+				return
+			}
+
+			c, err := e.connectToRedis()
+			if c != nil {
+				c.Close()
+			}
+			var redisErr redis.Error
+			if !errors.As(err, &redisErr) || !strings.HasPrefix(string(redisErr), "WRONGPASS ") {
+				t.Fatalf("connectToRedis() = %v; want Redis WRONGPASS error", err)
+			}
+			requireConnectionTestScrape(t, e, "0",
+				`test_exporter_last_scrape_error{err="`+err.Error()+`"} 1`)
+		})
+	}
+}


### PR DESCRIPTION
Add TLS regression coverage for passwords supplied in the URL or exporter options, using the existing Valkey 9 TLS Docker fixture. Valid passwords connect; invalid passwords must preserve `WRONGPASS` and report `up=0`.

Verified against freshly pulled Valkey 9.1.2 through `make test` with `-race`, plus the existing Valkey TLS test and `go vet`. Both bad-password cases fail against the old connection code.
